### PR TITLE
Simulated the synchrotron topup PVs and had them "link" #22

### DIFF
--- a/examples/configs/synchrotron.yaml
+++ b/examples/configs/synchrotron.yaml
@@ -1,7 +1,7 @@
 - tickit_devices.synchrotron.synchrotron_current.SynchrotronCurrent:
     name: sync_current
     inputs: {}
-    callback_period: 10000000
+    callback_period: 100000000
     initial_current: 300
     port: 25565
 - tickit.devices.sink.Sink:
@@ -24,7 +24,6 @@
      current: sync_current:current
     port: 25563
     callback_period: 1000000000
-    current_callback_period: 10000000
 - tickit.devices.sink.Sink:
     name: topup_sink
     inputs:

--- a/examples/configs/synchrotron.yaml
+++ b/examples/configs/synchrotron.yaml
@@ -23,7 +23,7 @@
     inputs:
      current: sync_current:current
     port: 25563
-    callback_period: 1000000000
+    callback_period: 100000000
 - tickit.devices.sink.Sink:
     name: topup_sink
     inputs:

--- a/examples/configs/synchrotron.yaml
+++ b/examples/configs/synchrotron.yaml
@@ -1,6 +1,7 @@
 - tickit_devices.synchrotron.synchrotron_current.SynchrotronCurrent:
     name: sync_current
     inputs: {}
+    callback_period: 10000000
     initial_current: 300
     port: 25565
 - tickit.devices.sink.Sink:
@@ -19,8 +20,11 @@
 
 - tickit_devices.synchrotron.synchrotron_topup.SynchrotronTopUp:
     name: sync_topup
-    inputs: {}
+    inputs:
+     current: sync_current:current
     port: 25563
+    callback_period: 1000000000
+    current_callback_period: 10000000
 - tickit.devices.sink.Sink:
     name: topup_sink
     inputs:

--- a/examples/configs/synchrotron_current.yaml
+++ b/examples/configs/synchrotron_current.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-#For running the full synchrotron use examples/configs/synchrotron.yaml
+# For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_current.SynchrotronCurrent:
     name: sync_current

--- a/examples/configs/synchrotron_current.yaml
+++ b/examples/configs/synchrotron_current.yaml
@@ -1,3 +1,6 @@
+# This is the individual part of the synchrotron - useful for tests but not much else
+# For running use examples/configs/synchrotron.yaml
+
 - tickit_devices.synchrotron.synchrotron_current.SynchrotronCurrent:
     name: sync_current
     inputs: {}

--- a/examples/configs/synchrotron_current.yaml
+++ b/examples/configs/synchrotron_current.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-# For running use examples/configs/synchrotron.yaml
+#For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_current.SynchrotronCurrent:
     name: sync_current

--- a/examples/configs/synchrotron_machine.yaml
+++ b/examples/configs/synchrotron_machine.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-#For running the full synchrotron use examples/configs/synchrotron.yaml
+# For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_machine.SynchrotronMachineStatus:
     name: sync_machine

--- a/examples/configs/synchrotron_machine.yaml
+++ b/examples/configs/synchrotron_machine.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-# For running use examples/configs/synchrotron.yaml
+#For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_machine.SynchrotronMachineStatus:
     name: sync_machine

--- a/examples/configs/synchrotron_machine.yaml
+++ b/examples/configs/synchrotron_machine.yaml
@@ -1,3 +1,6 @@
+# This is the individual part of the synchrotron - useful for tests but not much else
+# For running use examples/configs/synchrotron.yaml
+
 - tickit_devices.synchrotron.synchrotron_machine.SynchrotronMachineStatus:
     name: sync_machine
     inputs: {}

--- a/examples/configs/synchrotron_topup.yaml
+++ b/examples/configs/synchrotron_topup.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-# For running use examples/configs/synchrotron.yaml
+#For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_topup.SynchrotronTopUp:
     name: sync_topup

--- a/examples/configs/synchrotron_topup.yaml
+++ b/examples/configs/synchrotron_topup.yaml
@@ -1,7 +1,13 @@
+# This is the individual part of the synchrotron - useful for tests but not much else
+# For running use examples/configs/synchrotron.yaml
+
 - tickit_devices.synchrotron.synchrotron_topup.SynchrotronTopUp:
     name: sync_topup
     inputs: {}
     port: 25563
+    initial_countdown: 30
+    initial_end_countdown: 40
+    callback_period: 1e9
 - tickit.devices.sink.Sink:
     name: topup_sink
     inputs:

--- a/examples/configs/synchrotron_topup.yaml
+++ b/examples/configs/synchrotron_topup.yaml
@@ -1,5 +1,5 @@
 # This is the individual part of the synchrotron - useful for tests but not much else
-#For running the full synchrotron use examples/configs/synchrotron.yaml
+# For running the full synchrotron use examples/configs/synchrotron.yaml
 
 - tickit_devices.synchrotron.synchrotron_topup.SynchrotronTopUp:
     name: sync_topup

--- a/tests/synchrotron/test_synchrotron_current.py
+++ b/tests/synchrotron/test_synchrotron_current.py
@@ -23,7 +23,26 @@ def test_synchrotron_current_set_and_get_current(
     assert synchrotron_current.get_current() == INITIAL_CURRENT
 
 
-def test_synchrotron_current_update(synchrotron_current: SynchrotronCurrentDevice):
+def test_synchrotron_current_lose_current_update(
+    synchrotron_current: SynchrotronCurrentDevice,
+):
+    loss_increment = (270 - INITIAL_CURRENT) / 600
+    expected_output = INITIAL_CURRENT + loss_increment
     device_update: DeviceUpdate = synchrotron_current.update(SimTime(0), inputs={})
-    assert device_update.outputs["current"] == INITIAL_CURRENT
-    assert device_update.call_at is None
+    assert device_update.outputs["current"] == expected_output
+
+
+def test_synchrotron_current_topup_fill_update():
+    INITIAL_CURRENT = 239
+    fill_incremenet = (300 - 270) / 15
+    expected_output = INITIAL_CURRENT + fill_incremenet
+    device_update: DeviceUpdate = SynchrotronCurrentDevice(
+        initial_current=INITIAL_CURRENT
+    ).update(SimTime(0), inputs={})
+    assert device_update.outputs["current"] == expected_output
+
+
+def test_synchrotron_current_call_at(synchrotron_current: SynchrotronCurrentDevice):
+    device_update: DeviceUpdate = synchrotron_current.update(SimTime(0), inputs={})
+    expected_output = int(1e9)
+    assert device_update.call_at == expected_output

--- a/tests/synchrotron/test_synchrotron_current.py
+++ b/tests/synchrotron/test_synchrotron_current.py
@@ -4,7 +4,7 @@ from tickit.core.typedefs import SimTime
 
 from tickit_devices.synchrotron.synchrotron_current import SynchrotronCurrentDevice
 
-INITIAL_CURRENT = 400
+INITIAL_CURRENT = 300
 
 
 @pytest.fixture

--- a/tests/synchrotron/test_synchrotron_topup.py
+++ b/tests/synchrotron/test_synchrotron_topup.py
@@ -4,14 +4,16 @@ from tickit.core.typedefs import SimTime
 
 from tickit_devices.synchrotron.synchrotron_topup import SynchrotronTopUpDevice
 
-COUNTDOWN = 800
-ENDCOUNTDN = 810
+COUNTDOWN = 600
+ENDCOUNTDN = 620
 
 
 @pytest.fixture
 def synchrotron_topup() -> SynchrotronTopUpDevice:
     return SynchrotronTopUpDevice(
-        initial_countdown=COUNTDOWN, initial_end_countdown=ENDCOUNTDN
+        initial_countdown=COUNTDOWN,
+        initial_end_countdown=ENDCOUNTDN,
+        callback_period=int(1e9),
     )
 
 
@@ -21,16 +23,47 @@ def test_synchrotron_topup_constructor(
     pass
 
 
-def test_synchrotron_topup_set_and_get_countdown(
+def test_synchrotron_topup_get_countdown(
     synchrotron_topup: SynchrotronTopUpDevice,
 ):
     synchrotron_topup.countdown = COUNTDOWN
     assert synchrotron_topup.get_countdown() == COUNTDOWN
 
 
-def test_synchrotron_topup_update(
+def test_synchrotron_topup_update_new_countdown(
     synchrotron_topup: SynchrotronTopUpDevice,
 ):
-    device_update: DeviceUpdate = synchrotron_topup.update(SimTime(0), inputs={})
-    assert device_update.outputs["countdown"] == COUNTDOWN
-    assert device_update.call_at is None
+    device_update: DeviceUpdate = synchrotron_topup.update(
+        SimTime(0), inputs={"current": 299.95}
+    )
+
+    COUNTDOWN = (299.95 - 270) / 0.05
+
+    # countdown seconds need to be rounded since the scheduler introduces slight changes
+    # many decimal places in
+    assert round(device_update.outputs["countdown"], -7) == round(COUNTDOWN, -7)
+    assert round(device_update.outputs["end_countdown"], -7) == round(
+        COUNTDOWN + 15, -7
+    )
+
+
+def test_synchrotron_topup_update_new_countdown_topup_fill():
+    synchrotron_topup = SynchrotronTopUpDevice(last_current=290)
+    device_update: DeviceUpdate = synchrotron_topup.update(
+        SimTime(0), inputs={"current": 291}
+    )
+
+    COUNTDOWN = (300 - 291) / (291 - 290)
+
+    # countdown seconds need to be rounded since the scheduler introduces slight changes
+    # many decimal places in
+    assert device_update.outputs["countdown"] == 0
+    assert device_update.outputs["end_countdown"] == COUNTDOWN
+
+
+def test_synchrotron_topup_call_at(synchrotron_topup: SynchrotronTopUpDevice):
+    device_update: DeviceUpdate = synchrotron_topup.update(
+        SimTime(0), inputs={"current": 289}
+    )
+    expected_output = int(1e9)
+    assert device_update.call_at == expected_output

--- a/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/tickit_devices/synchrotron/synchrotron_machine.py
@@ -188,7 +188,7 @@ class SynchrotronMachineStatusEpicsAdapter(EpicsAdapter):
 class SynchrotronMachineStatus(ComponentConfig):
     """Synchrotron Machine status component."""
 
-    initial_mode: int = 0
+    initial_mode: int = 4
     initial_countdown: float = 100000
     initial_energy: float = 3.0
     host: str = "localhost"


### PR DESCRIPTION
Simulated the current loss and current gain of the synchrotron storage ring. The current loss and gain increment are calculated so they will take 10 minutes and 15 seconds respectively. The countdown is also simulated: based on the change of the current (this will only really work as a method if the rate of change is constant). Also wrote tests.