### PR TITLE
Update the pypi badge to link to tickit-devices

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ to include it in S03.
     :target: https://codecov.io/gh/dls-controls/tickit-devices
     :alt: Test Coverage
 
-.. |pypi_version| image:: https://img.shields.io/pypi/v/python3-pip-skeleton.svg
+.. |pypi_version| image:: https://img.shields.io/pypi/v/tickit-devices.svg
     :target: https://pypi.org/project/tickit-devices
     :alt: Latest PyPI version
 


### PR DESCRIPTION
The pypi bade on the readme was still linked to the skeleton. This will link it to tickit-devices instead,