### PR TITLE
Artemis516 458 remove prefix from synchrotron devices

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -93,6 +93,12 @@ jobs:
           name: dist
           path: dist
 
+      - name: Upload S03 configs as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: s03_configs
+          path: s03_configs
+
       - name: Check for packaging errors
         run: pipx run twine check --strict dist/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,11 @@ RUN pip install ${PIP_OPTIONS}
 FROM python:3.10-slim as runtime
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends net-tools lsof 
+RUN apt-get install -y --no-install-recommends lsof 
 
 # copy the virtual environment from the build stage and put it in PATH
 COPY --from=build /venv/ /venv/
+
 # copy configs
-COPY s03_configs/ s03_configs/
+COPY --from=build /context/s03_configs s03_configs/
 ENV PATH=/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,6 @@ FROM python:3.10-slim as runtime
 
 # copy the virtual environment from the build stage and put it in PATH
 COPY --from=build /venv/ /venv/
+# copy configs
+COPY s03_configs/ s03_configs/
 ENV PATH=/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,6 @@ ARG PIP_OPTIONS=.
 #     desired-packages \
 #     && rm -rf /var/lib/apt/lists/*
 
-# Useful for checking if port for PV service is correct
-# RUN apt-get update
-# RUN apt-get install -y --no-install-recommends lsof 
-
 # set up a virtual environment and put it in PATH
 RUN python -m venv /venv
 ENV PATH=/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ RUN apt-get install -y --no-install-recommends lsof
 COPY --from=build /venv/ /venv/
 
 # copy configs
-COPY --from=build /context/s03_configs s03_configs/
+COPY --from=build /context/s03_configs/ s03_configs/
 ENV PATH=/venv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN pip install ${PIP_OPTIONS}
 
 FROM python:3.10-slim as runtime
 
-# Add apt-get system dependecies for runtime here if needed
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends net-tools lsof 
 
 # copy the virtual environment from the build stage and put it in PATH
 COPY --from=build /venv/ /venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ARG PIP_OPTIONS=.
 #     desired-packages \
 #     && rm -rf /var/lib/apt/lists/*
 
+# Useful for checking if port for PV service is correct
+# RUN apt-get update
+# RUN apt-get install -y --no-install-recommends lsof 
+
 # set up a virtual environment and put it in PATH
 RUN python -m venv /venv
 ENV PATH=/venv/bin:$PATH
@@ -26,12 +30,9 @@ RUN pip install ${PIP_OPTIONS}
 
 FROM python:3.10-slim as runtime
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends lsof 
-
 # copy the virtual environment from the build stage and put it in PATH
 COPY --from=build /venv/ /venv/
-
 # copy configs
-COPY --from=build /context/s03_configs/ s03_configs/
+COPY ./s03_configs/ s03_configs
+
 ENV PATH=/venv/bin:$PATH

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ tickit-devices
 A collection of devices simulated using the `tickit <https://github.com/dls-controls/tickit>`_ framework.
 
 Note: These devices mimic real synchrotron devices and there is the potential for conflict with the real PVs if this is run on the same port as EPICS (5064).
-If using this simulation to test software, set your `EPICS_CA_SERVER_PORT` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
-tests are not confused between these and the real PVs. The [S03](https://gitlab.diamond.ac.uk/controls/python3/s03_utils) startup scripts manage the setting of
+If using this simulation to test software, set your ``EPICS_CA_SERVER_PORT`` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
+tests are not confused between these and the real PVs. The `S03<https://gitlab.diamond.ac.uk/controls/python3/s03_utils>`_ startup scripts manage the setting of
 these ports automatically, so if you are using this as part of S03 you won't need to change anything. Do not run this simulation on a beamline controls machine!
 
 ============== ==============================================================

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ A collection of devices simulated using the `tickit <https://github.com/dls-cont
 
 Note: These devices mimic real synchrotron devices and there is the potential for conflict with the real PVs if this is run on the same port as EPICS (5064).
 If using this simulation to test software, set your ``EPICS_CA_SERVER_PORT`` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
-tests are not confused between these and the real PVs. The `S03<https://gitlab.diamond.ac.uk/controls/python3/s03_utils>`_ startup scripts manage the setting of
+tests are not confused between these and the real PVs. The `S03 <https://gitlab.diamond.ac.uk/controls/python3/s03_utils>`_ startup scripts manage the setting of
 these ports automatically, so if you are using this as part of S03 you won't need to change anything. Do not run this simulation on a beamline controls machine!
 
 ============== ==============================================================

--- a/README.rst
+++ b/README.rst
@@ -5,17 +5,20 @@ tickit-devices
 
 A collection of devices simulated using the `tickit <https://github.com/dls-controls/tickit>`_ framework.
 
-Note: These devices mimic real synchrotron devices and there is the potential for conflict with the real PVs if this is run on the same port as EPICS (5064).
-If using this simulation to test software, set your ``EPICS_CA_SERVER_PORT`` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
-tests are not confused between these and the real PVs. The `S03 <https://gitlab.diamond.ac.uk/controls/python3/s03_utils>`_ startup scripts manage the setting of
-these ports automatically, so if you are using this as part of S03 you won't need to change anything. Do not run this simulation on a beamline controls machine!
-
 ============== ==============================================================
 PyPI           ``pip install tickit-devices``
 Source code    https://github.com/dls-controls/tickit-devices
 Documentation  https://dls-controls.github.io/tickit-devices
 Releases       https://github.com/dls-controls/tickit-devices/releases
 ============== ==============================================================
+
+
+Safety Note
+------------------------------------
+These devices mimic real synchrotron devices and there is the potential for conflict with the real PVs if this is run on the same port as EPICS (5064).
+If using this simulation to test software, set your ``EPICS_CA_SERVER_PORT`` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
+tests are not confused between these and the real PVs. The `S03 <https://gitlab.diamond.ac.uk/controls/python3/s03_utils>`_ startup scripts manage the setting of
+these ports automatically, so if you are using this as part of S03 you won't need to change anything. Do not run this simulation on a beamline controls machine!
 
 
 Adding devices to the S03 simulation

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,11 @@ tickit-devices
 
 A collection of devices simulated using the `tickit <https://github.com/dls-controls/tickit>`_ framework.
 
+Note: These devices mimic real synchrotron devices and there is the potential for conflict with the real PVs if this is run on the same port as EPICS (5064).
+If using this simulation to test software, set your `EPICS_CA_SERVER_PORT` environment variable to something nonstandard, e.g. 5065 or greater, so that your 
+tests are not confused between these and the real PVs. The [S03](https://gitlab.diamond.ac.uk/controls/python3/s03_utils) startup scripts manage the setting of
+these ports automatically, so if you are using this as part of S03 you won't need to change anything. Do not run this simulation on a beamline controls machine!
+
 ============== ==============================================================
 PyPI           ``pip install tickit-devices``
 Source code    https://github.com/dls-controls/tickit-devices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit"
+    "tickit",
+    "typing_extensions",
+    "softioc",
+    
 ] 
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "tickit",
     "typing_extensions",
     "softioc",
-    
 ] 
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/tickit_devices/synchrotron/db_files/DCCT.db
+++ b/src/tickit_devices/synchrotron/db_files/DCCT.db
@@ -7,7 +7,7 @@
 #    field (DISS, "3")
 #}
 
-record (ai, "BL03S-SR-DI-DCCT-01:SIGNAL")
+record (ai, "SR-DI-DCCT-01:SIGNAL")
 {
     field (SCAN, "5 second")
     field (DISS, "3")

--- a/src/tickit_devices/synchrotron/db_files/FILL.db
+++ b/src/tickit_devices/synchrotron/db_files/FILL.db
@@ -1,5 +1,5 @@
 #Real world PV= SR-CS-FILL-01:COUNTDOWN
-record (ai, "BL03S-SR-CS-FILL-01:COUNTDOWN")
+record (ai, "SR-CS-FILL-01:COUNTDOWN")
 {
     field (DESC, "seconds until next fill")
     field (VAL,  "-1.0")
@@ -8,7 +8,7 @@ record (ai, "BL03S-SR-CS-FILL-01:COUNTDOWN")
     field (PINI, "1")
 }
 #Real world PV= SR-CS-FILL-01:ENDCOUNTDN
-record (ai, "BL03S-SR-CS-FILL-01:ENDCOUNTDN")
+record (ai, "SR-CS-FILL-01:ENDCOUNTDN")
 {
     field (DESC, "secs until end of next fill")
     field (VAL,  "-1")

--- a/src/tickit_devices/synchrotron/db_files/MSTAT.db
+++ b/src/tickit_devices/synchrotron/db_files/MSTAT.db
@@ -1,5 +1,5 @@
 #Real world PV= CS-CS-MSTAT-01:MODE
-record (mbbi, "BL03S-CS-CS-MSTAT-01:MODE")
+record (mbbi, "CS-CS-MSTAT-01:MODE")
 {
     field (SCAN, "Passive")
     field (DESC, "Mode")

--- a/src/tickit_devices/synchrotron/synchrotron_current.py
+++ b/src/tickit_devices/synchrotron/synchrotron_current.py
@@ -1,3 +1,4 @@
+import pathlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -166,7 +167,7 @@ class SynchrotronCurrent(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = "src/tickit_devices/synchrotron/db_files/DCCT.db"
+    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/DCCT.db"
     ioc_name: str = "SR-DI-DCCT-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/src/tickit_devices/synchrotron/synchrotron_current.py
+++ b/src/tickit_devices/synchrotron/synchrotron_current.py
@@ -167,7 +167,7 @@ class SynchrotronCurrent(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/DCCT.db"
+    db_file: str = str(pathlib.Path(__file__).parent.absolute() / "db_files/DCCT.db")
     ioc_name: str = "SR-DI-DCCT-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/src/tickit_devices/synchrotron/synchrotron_current.py
+++ b/src/tickit_devices/synchrotron/synchrotron_current.py
@@ -167,7 +167,7 @@ class SynchrotronCurrent(ComponentConfig):
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
     db_file: str = "src/tickit_devices/synchrotron/db_files/DCCT.db"
-    ioc_name: str = "BL03S-SR-DI-DCCT-01"
+    ioc_name: str = "SR-DI-DCCT-01"
 
     def __call__(self) -> Component:  # noqa: D102
         return DeviceSimulation(

--- a/src/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/src/tickit_devices/synchrotron/synchrotron_machine.py
@@ -1,3 +1,4 @@
+import pathlib
 from dataclasses import dataclass
 
 from softioc import builder
@@ -194,7 +195,7 @@ class SynchrotronMachineStatus(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = "src/tickit_devices/synchrotron/db_files/MSTAT.db"
+    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/MSTAT.db"
     ioc_name: str = "CS-CS-MSTAT-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/src/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/src/tickit_devices/synchrotron/synchrotron_machine.py
@@ -195,7 +195,7 @@ class SynchrotronMachineStatus(ComponentConfig):
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
     db_file: str = "src/tickit_devices/synchrotron/db_files/MSTAT.db"
-    ioc_name: str = "BL03S-CS-CS-MSTAT-01"
+    ioc_name: str = "CS-CS-MSTAT-01"
 
     def __call__(self) -> Component:  # noqa: D102
         return DeviceSimulation(

--- a/src/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/src/tickit_devices/synchrotron/synchrotron_machine.py
@@ -195,7 +195,7 @@ class SynchrotronMachineStatus(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/MSTAT.db"
+    db_file: str = str(pathlib.Path(__file__).parent.absolute() / "db_files/MSTAT.db")
     ioc_name: str = "CS-CS-MSTAT-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/src/tickit_devices/synchrotron/synchrotron_topup.py
+++ b/src/tickit_devices/synchrotron/synchrotron_topup.py
@@ -216,7 +216,7 @@ class SynchrotronTopUp(ComponentConfig):
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
     db_file: str = "src/tickit_devices/synchrotron/db_files/FILL.db"
-    ioc_name: str = "BL03S-SR-CS-FILL-01"
+    ioc_name: str = "SR-CS-FILL-01"
 
     def __call__(self) -> Component:  # noqa: D102
         return DeviceSimulation(

--- a/src/tickit_devices/synchrotron/synchrotron_topup.py
+++ b/src/tickit_devices/synchrotron/synchrotron_topup.py
@@ -216,7 +216,7 @@ class SynchrotronTopUp(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/FILL.db"
+    db_file: str = str(pathlib.Path(__file__).parent.absolute() / "db_files/FILL.db")
     ioc_name: str = "SR-CS-FILL-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/src/tickit_devices/synchrotron/synchrotron_topup.py
+++ b/src/tickit_devices/synchrotron/synchrotron_topup.py
@@ -1,3 +1,4 @@
+import pathlib
 from dataclasses import dataclass
 
 from softioc import builder
@@ -215,7 +216,7 @@ class SynchrotronTopUp(ComponentConfig):
     host: str = "localhost"
     port: int = 25565
     format: ByteFormat = ByteFormat(b"%b\r\n")
-    db_file: str = "src/tickit_devices/synchrotron/db_files/FILL.db"
+    db_file: str = pathlib.Path(__file__).parent.absolute() / "db_files/FILL.db"
     ioc_name: str = "SR-CS-FILL-01"
 
     def __call__(self) -> Component:  # noqa: D102

--- a/tests/synchrotron/test_synchrotron.py
+++ b/tests/synchrotron/test_synchrotron.py
@@ -9,4 +9,4 @@ USER_MODE = 4
     "tickit_process", ["examples/configs/synchrotron/synchrotron.yaml"], indirect=True
 )
 async def test_synchrotron_system(tickit_process):
-    assert (await caget("BL03S-CS-CS-MSTAT-01:MODE")) == USER_MODE
+    assert (await caget("CS-CS-MSTAT-01:MODE")) == USER_MODE


### PR DESCRIPTION
Removes the `BL03S` prefixes from PVs - goes with changes in
Artemis: https://github.com/DiamondLightSource/python-artemis/pull/566
and S03: https://gitlab.diamond.ac.uk/controls/python3/s03_utils/-/merge_requests/9

Also some minor bugfixes like including the synchrotron.yaml, epics db paths relative to the module