### PR TITLE
Add vscode debug configuration for running a simulated device

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name":"Device Simulation",
+            "type":"python",
+            "request":"launch",
+            "module":"tickit",
+            "justMyCode":false,
+            "console": "integratedTerminal",
+            "args": ["all", "${input:deviceConfig}"]
+        },
+        {
             "name": "Debug Unit Test",
             "type": "python",
             "request": "launch",
@@ -21,5 +30,22 @@
                 "PYTEST_ADDOPTS": "--no-cov"
             },
         }
-    ]
+    ],
+    // Requires the following extension:
+    // Name: Command Variable
+    // Id: rioj7.command-variable
+    // Description: Calculate command variables for launch.json and tasks.json
+    // Version: 1.54.1
+    // Publisher: rioj7
+    // VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=rioj7.command-variable
+    "inputs": [
+        {
+          "id": "deviceConfig",
+          "type": "command",
+          "command": "extension.commandvariable.file.pickFile",
+          "args": {
+            "include": "examples/**/*.{yaml,yml}",
+          }
+        }
+      ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
           "type": "command",
           "command": "extension.commandvariable.file.pickFile",
           "args": {
-            "include": "examples/**/*.{yaml,yml}",
+            "include": "{examples,s03_configs}/**/*.{yaml,yml}",
           }
         }
       ]


### PR DESCRIPTION
Add vscode debug configuration for running a simulated device.

The configuration automatically detects all config files in `examples/` and `s03_configs/` and and prompts the user to pick one (with filtering based on typed input) when they run the configuration. This does require an additional extension (documented in `launch.json`).

The alternative, if we did not want the additional extension, is to manually maintain a list of possible configuration files, meaning when one is added, moved, or deleted we must remember to update `launch.json`. This would otherwise provide the same user experience.

Thoughts welcome.