### PR TITLE
Remove typing_compat module and use typing directly

### DIFF
--- a/src/tickit_devices/cryostream/cryostream.py
+++ b/src/tickit_devices/cryostream/cryostream.py
@@ -1,6 +1,6 @@
 import asyncio
 import struct
-from typing import AsyncIterable
+from typing import AsyncIterable, TypedDict
 
 from tickit.adapters.composed import ComposedAdapter
 from tickit.adapters.interpreters.command import CommandInterpreter, RegexCommand
@@ -8,7 +8,6 @@ from tickit.adapters.servers.tcp import TcpServer
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
-from tickit.utils.compat.typing_compat import TypedDict
 
 from tickit_devices.cryostream.base import CryostreamBase
 from tickit_devices.cryostream.states import PhaseIds

--- a/src/tickit_devices/eiger/eiger.py
+++ b/src/tickit_devices/eiger/eiger.py
@@ -1,10 +1,10 @@
 import logging
 from dataclasses import fields
+from typing import TypedDict
 
 from apischema import serialize
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
-from typing_extensions import TypedDict
 
 from tickit_devices.eiger.data.dummy_image import Image
 from tickit_devices.eiger.eiger_schema import AccessMode, Value

--- a/src/tickit_devices/eiger/filewriter/eiger_filewriter.py
+++ b/src/tickit_devices/eiger/filewriter/eiger_filewriter.py
@@ -1,10 +1,10 @@
 import logging
+from typing import TypedDict
 
 from aiohttp import web
 from apischema import serialize
 from tickit.adapters.interpreters.endpoints.http_endpoint import HTTPEndpoint
 from tickit.core.typedefs import SimTime
-from typing_extensions import TypedDict
 
 from tickit_devices.eiger.eiger_schema import Value
 from tickit_devices.eiger.filewriter.filewriter_config import FileWriterConfig

--- a/src/tickit_devices/eiger/monitor/eiger_monitor.py
+++ b/src/tickit_devices/eiger/monitor/eiger_monitor.py
@@ -1,10 +1,10 @@
 import logging
+from typing import TypedDict
 
 from aiohttp import web
 from apischema import serialize
 from tickit.adapters.interpreters.endpoints.http_endpoint import HTTPEndpoint
 from tickit.core.typedefs import SimTime
-from typing_extensions import TypedDict
 
 from tickit_devices.eiger.eiger_schema import Value
 from tickit_devices.eiger.monitor.monitor_config import MonitorConfig

--- a/src/tickit_devices/eiger/stream/eiger_stream.py
+++ b/src/tickit_devices/eiger/stream/eiger_stream.py
@@ -1,10 +1,10 @@
 import logging
+from typing import TypedDict
 
 from aiohttp import web
 from apischema import serialize
 from tickit.adapters.interpreters.endpoints.http_endpoint import HTTPEndpoint
 from tickit.core.typedefs import SimTime
-from typing_extensions import TypedDict
 
 from tickit_devices.eiger.eiger_schema import Value
 from tickit_devices.eiger.stream.stream_config import StreamConfig

--- a/src/tickit_devices/femto/current.py
+++ b/src/tickit_devices/femto/current.py
@@ -1,8 +1,8 @@
 from random import uniform
+from typing import TypedDict
 
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class CurrentDevice(Device):

--- a/src/tickit_devices/femto/femto.py
+++ b/src/tickit_devices/femto/femto.py
@@ -1,8 +1,9 @@
+from typing import TypedDict
+
 from softioc import builder
 from tickit.adapters.epicsadapter import EpicsAdapter
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class FemtoDevice(Device):

--- a/src/tickit_devices/pneumatic/pneumatic.py
+++ b/src/tickit_devices/pneumatic/pneumatic.py
@@ -1,8 +1,9 @@
+from typing import TypedDict
+
 from softioc import builder
 from tickit.adapters.epicsadapter import EpicsAdapter
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class PneumaticDevice(Device):

--- a/src/tickit_devices/synchrotron/synchrotron_current.py
+++ b/src/tickit_devices/synchrotron/synchrotron_current.py
@@ -1,6 +1,6 @@
 import pathlib
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, TypedDict
 
 from softioc import builder
 from tickit.adapters.composed import ComposedAdapter
@@ -13,7 +13,6 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class SynchrotronCurrentDevice(Device):

--- a/src/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/src/tickit_devices/synchrotron/synchrotron_machine.py
@@ -1,5 +1,6 @@
 import pathlib
 from dataclasses import dataclass
+from typing import TypedDict
 
 from softioc import builder
 from tickit.adapters.composed import ComposedAdapter
@@ -12,7 +13,6 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class SynchrotronMachineStatusDevice(Device):

--- a/src/tickit_devices/synchrotron/synchrotron_topup.py
+++ b/src/tickit_devices/synchrotron/synchrotron_topup.py
@@ -1,5 +1,6 @@
 import pathlib
 from dataclasses import dataclass
+from typing import TypedDict
 
 from softioc import builder
 from tickit.adapters.composed import ComposedAdapter
@@ -12,7 +13,6 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
-from tickit.utils.compat.typing_compat import TypedDict
 
 
 class SynchrotronTopUpDevice(Device):


### PR DESCRIPTION
typing_compat was required to support pre-3.8 versions on Python. As
support for these versions is no longer required, this module is
redundant.
