### PR TITLE
Drop support for Python3.8

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -32,12 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10"]
         install: ["-e .[dev]"]
         # Make one version be non-editable to test both paths of version code
         include:
           - os: "ubuntu-latest"
-            python: "3.8"
+            python: "3.9"
             install: ".[dev]"
 
     runs-on: ${{ matrix.os }}

--- a/docs/developer/how-to/pin-requirements.rst
+++ b/docs/developer/how-to/pin-requirements.rst
@@ -46,7 +46,7 @@ of the dependencies and sub-dependencies with pinned versions.
 You can download any of these files by clicking on them. It is best to use
 the one that ran with the lowest Python version as this is more likely to
 be compatible with all the versions of Python in the test matrix.
-i.e. ``requirements-test-ubuntu-latest-3.8.txt`` in this example.
+i.e. ``requirements-test-ubuntu-latest-3.9.txt`` in this example.
 
 Applying the lock file
 ----------------------

--- a/docs/developer/tutorials/dev-install.rst
+++ b/docs/developer/tutorials/dev-install.rst
@@ -16,7 +16,7 @@ Install dependencies
 --------------------
 
 You can choose to either develop on the host machine using a `venv` (which
-requires python 3.8 or later) or to run in a container under `VSCode
+requires python 3.9 or later) or to run in a container under `VSCode
 <https://code.visualstudio.com/>`_
 
 .. tab-set::

--- a/docs/user/tutorials/installation.rst
+++ b/docs/user/tutorials/installation.rst
@@ -4,7 +4,7 @@ Installation
 Check your version of python
 ----------------------------
 
-You will need python 3.8 or later. You can check your version of python by
+You will need python 3.9 or later. You can check your version of python by
 typing into a terminal::
 
     $ python3 --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "tickit-devices"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
@@ -20,7 +19,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit",
+    "tickit<0.2.3",
     "typing_extensions",
     "softioc",
 ] 


### PR DESCRIPTION
Remove support for Python3.8 in line with https://github.com/dls-controls/tickit/pull/157. There is no point in supporting versions of Python that the core library does not also support.

Version of tickit pinned due to breaking changes that will be resolved by #54 