### PR TITLE
Pin tickit to avoid breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit>=0.3,<0.4",
+    "tickit==0.3",
     "typing_extensions",
     "softioc",
     "pydantic>1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit>=0.3",
+    "tickit>=0.3,<0.4",
     "typing_extensions",
     "softioc",
     "pydantic>1",


### PR DESCRIPTION
Pin tickit to avoid breaking changes while the adapters get converted in tickit-devices.