### PR TITLE
Add Zebra System simulation with AND|OR block support

### DIFF
--- a/examples/configs/zebra/zebra.yaml
+++ b/examples/configs/zebra/zebra.yaml
@@ -31,7 +31,6 @@
     bang:
       component: bang
       port: output
-  muxes: { }
   components:
     - type: tickit_devices.zebra.and_or_block.AndOrBlockConfig
       name: AND1

--- a/examples/configs/zebra/zebra.yaml
+++ b/examples/configs/zebra/zebra.yaml
@@ -1,0 +1,2 @@
+- type: tickit_devices.zebra.zebra
+  name: zebra

--- a/examples/configs/zebra/zebra.yaml
+++ b/examples/configs/zebra/zebra.yaml
@@ -1,46 +1,68 @@
-- type: tickit.devices.source.Source
-  name: source
-  inputs: { }
-  value: true
+- type: tests.zebra.devices.Counter
+  name: count
+  inputs: {}
 
+- type: tests.zebra.devices.DividingConfig
+  name: fizz
+  denominator: 3
+  inputs:
+    input:
+      component: count
+      port: value
+
+- type: tests.zebra.devices.DividingConfig
+  name: bang
+  denominator: 5
+  inputs:
+    input:
+      component: count
+      port: value
+  value: true
 
 - type: tickit_devices.zebra.Zebra
   name: zebra
   params:
-    AND1_ENA: 154
+    AND1_ENA: 15 # Enable all inputs
+    AND1_INV: 12 # Invert INP3, INP4 as they will be false
   inputs:
-    initial_signal:
-      component: external
-      port: input_1
+    fizz:
+      component: fizz
+      port: output
+    bang:
+      component: bang
+      port: output
   muxes: { }
   components:
-    - type: AndOrBlockConfig
+    - type: tickit_devices.zebra.and_or_block.AndOrBlockConfig
       name: AND1
       inputs:
         INP1:
           component: external
-          port: input_1
-
+          port: fizz
         INP2:
           component: external
-          port: input_1
-        INP3:
-          component: external
-          port: input_1
-        INP4:
-          component: external
-          port: input_1
-  #    - type: AndOrBlockConfig
-  #      name: AND2
-  #      inputs: { }
+          port: bang
   expose:
-    output_1:
+    fizzbang:
       component: AND1
       port: OUT
+
+- type: tests.zebra.devices.FizzBang
+  name: fizzbang
+  inputs:
+    fizz:
+      component: fizz
+      port: output
+    bang:
+      component: bang
+      port: output
+    fizzbang:
+      component: zebra
+      port: fizzbang
 
 - type: tickit.devices.sink.Sink
   name: external_sink
   inputs:
     sink_1:
-      component: zebra
-      port: output_1
+      component: fizzbang
+      port: output

--- a/examples/configs/zebra/zebra.yaml
+++ b/examples/configs/zebra/zebra.yaml
@@ -1,2 +1,46 @@
-- type: tickit_devices.zebra.zebra
+- type: tickit.devices.source.Source
+  name: source
+  inputs: { }
+  value: true
+
+
+- type: tickit_devices.zebra.Zebra
   name: zebra
+  params:
+    AND1_ENA: 154
+  inputs:
+    initial_signal:
+      component: external
+      port: input_1
+  muxes: { }
+  components:
+    - type: AndOrBlockConfig
+      name: AND1
+      inputs:
+        INP1:
+          component: external
+          port: input_1
+
+        INP2:
+          component: external
+          port: input_1
+        INP3:
+          component: external
+          port: input_1
+        INP4:
+          component: external
+          port: input_1
+  #    - type: AndOrBlockConfig
+  #      name: AND2
+  #      inputs: { }
+  expose:
+    output_1:
+      component: AND1
+      port: OUT
+
+- type: tickit.devices.sink.Sink
+  name: external_sink
+  inputs:
+    sink_1:
+      component: zebra
+      port: output_1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit>=0.4.1",
+    "tickit>=0.4.2",
     "typing_extensions",
     "softioc",
     "pydantic>1",

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -1,0 +1,21 @@
+import pydantic.v1.dataclasses
+
+from tickit.core.components.component import Component
+from tickit.core.components.system_simulation import SystemSimulation
+
+from tickit_devices.zebra.zebra import ZebraDevice
+
+
+@pydantic.v1.dataclasses.dataclass
+class Zebra(SystemSimulation):
+    """Zebra simulation with TCP server."""
+
+    host: str = "localhost"
+    port: int = 7012
+
+    def __call__(self) -> Component:  # noqa: D102
+        return ZebraDevice(
+            name=self.name,
+            host=self.host,
+            port=self.port,
+        )

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -1,14 +1,14 @@
-from typing import List
+from typing import Dict, List
 
 import pydantic.v1.dataclasses
 from pydantic import Field
 from tickit.adapters.io import TcpIo
 from tickit.core.adapter import AdapterContainer
+from tickit.core.components.component import ComponentConfig
 from tickit.core.components.system_simulation import (
-    SystemSimulation,
     SystemSimulationComponent,
 )
-from tickit.core.typedefs import ComponentID
+from tickit.core.typedefs import ComponentID, PortID, ComponentPort
 
 from tickit_devices.zebra._common import default_filler, mux_types, param_types
 from tickit_devices.zebra.and_or_block import AndOrBlockConfig, BlockConfig
@@ -16,27 +16,25 @@ from tickit_devices.zebra.zebra import ZebraAdapter
 
 
 @pydantic.v1.dataclasses.dataclass
-class Zebra(SystemSimulation):
+class Zebra(ComponentConfig):
     """Zebra simulation with TCP server."""
 
+    name: ComponentID
+    inputs: Dict[PortID, ComponentPort]
+    components: List[BlockConfig]
+    expose: Dict[PortID, ComponentPort]
     host: str = "localhost"
     port: int = 7012
     params: dict[str, int] = Field(default_factory=default_filler(param_types))
     muxes: dict[str, int] = Field(default_factory=default_filler(mux_types))
-    components = List[BlockConfig]
 
     def __call__(self) -> SystemSimulationComponent:
-        andor_blocks = [
-            AndOrBlockConfig(name=ComponentID(f"{ANDOR}{num}"), params=self.params)
-            for ANDOR in {"AND", "OR"}
-            for num in range(4)
-        ]
         return SystemSimulationComponent(
             adapter=AdapterContainer(
                 adapter=ZebraAdapter(params=self.params, muxes=self.muxes),
                 io=TcpIo(host=self.host, port=self.port),
             ),
-            components=andor_blocks,
+            components=self.components,
             expose=self.expose,
             name=self.name,
         )

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -23,12 +23,8 @@ class Zebra(ComponentConfig):
     """
     Simulation of a Zebra device with a TCP server for reading/setting params/muxes
     (see `ZebraAdapter` for what read/set is available); Block wiring is currently
-    invariant while Tickit is running.
-
-    As rewiring while running is not currently supported, only those blocks that are
-    configured in the components configuration are instantiated, and attempting to
-    read or write to params/muxes that are on blocks that are not instantiated will
-    return 0.
+    invariant while Tickit is running, and only those blocks that are configured in
+    components are instantiated.
 
     Configuration that is currently passed down to Block behaviour from `params`:
     - For AND/OR gates N=1,2,3,4, the following (default 0) may be set
@@ -43,7 +39,7 @@ class Zebra(ComponentConfig):
     components: List[AndOrBlockConfig]
     host: str = "localhost"
     port: int = 7012
-    params: dict[str, int] = Field(default_factory=_default)
+    params: dict[str, int] = Field(default_factory=dict)
 
     @validator("params")
     def add_defaults(cls, v: dict[str, int]) -> dict[str, int]:

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -2,34 +2,57 @@ from typing import Dict, List
 
 import pydantic.v1.dataclasses
 from pydantic import Field
+from pydantic.v1 import validator
 from tickit.adapters.io import TcpIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import ComponentConfig
 from tickit.core.components.system_simulation import SystemSimulationComponent
 from tickit.core.typedefs import ComponentID, ComponentPort, PortID
 
-from tickit_devices.zebra._common import default_filler, mux_types, param_types
+from tickit_devices.zebra._common import param_types
 from tickit_devices.zebra.and_or_block import AndOrBlockConfig
 from tickit_devices.zebra.zebra import ZebraAdapter
 
 
+def _default() -> dict[str, int]:
+    return {k: 0 for k in param_types.keys()}
+
+
 @pydantic.v1.dataclasses.dataclass
 class Zebra(ComponentConfig):
-    """Zebra simulation with TCP server."""
+    """
+    Simulation of a Zebra device with a TCP server for reading/setting params/muxes
+    (see `ZebraAdapter` for what read/set is available); Block wiring is currently
+    invariant while Tickit is running.
+
+    As rewiring while running is not currently supported, only those blocks that are
+    configured in the components configuration are instantiated, and attempting to
+    read or write to params/muxes that are on blocks that are not instantiated will
+    return 0.
+
+    Configuration that is currently passed down to Block behaviour from `params`:
+    - For AND/OR gates N=1,2,3,4, the following (default 0) may be set
+    to Σ2**M where M is each input (1,2,3,4) for which the behaviour is desired.
+    {AND|OR}{N}_INV: Inverts input(s) M
+    {AND|OR}{N}_ENA: Enables input(s) M
+    """
 
     name: ComponentID
     inputs: Dict[PortID, ComponentPort]
-    components: List[AndOrBlockConfig]
     expose: Dict[PortID, ComponentPort]
+    components: List[AndOrBlockConfig]
     host: str = "localhost"
     port: int = 7012
-    params: dict[str, int] = Field(default_factory=default_filler(param_types))
-    muxes: dict[str, int] = Field(default_factory=default_filler(mux_types))
+    params: dict[str, int] = Field(default_factory=_default)
+
+    @validator("params")
+    def add_defaults(cls, v: dict[str, int]) -> dict[str, int]:
+        return {**_default(), **v}
 
     def __call__(self) -> SystemSimulationComponent:
         return SystemSimulationComponent(
             adapter=AdapterContainer(
-                adapter=ZebraAdapter(params=self.params, muxes=self.muxes),
+                adapter=ZebraAdapter(params=self.params),
                 io=TcpIo(host=self.host, port=self.port),
             ),
             components=self.components,

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -5,12 +5,10 @@ from pydantic import Field
 from tickit.adapters.io import TcpIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import ComponentConfig
-from tickit.core.components.system_simulation import (
-    SystemSimulationComponent,
-)
-from tickit.core.typedefs import ComponentID, PortID, ComponentPort
+from tickit.core.components.system_simulation import SystemSimulationComponent
+from tickit.core.typedefs import ComponentID, ComponentPort, PortID
 
-from tickit_devices.zebra._common import default_filler, mux_types, param_types, BlockConfig
+from tickit_devices.zebra._common import default_filler, mux_types, param_types
 from tickit_devices.zebra.and_or_block import AndOrBlockConfig
 from tickit_devices.zebra.zebra import ZebraAdapter
 

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -10,8 +10,8 @@ from tickit.core.components.system_simulation import (
 )
 from tickit.core.typedefs import ComponentID, PortID, ComponentPort
 
-from tickit_devices.zebra._common import default_filler, mux_types, param_types
-from tickit_devices.zebra.and_or_block import AndOrBlockConfig, BlockConfig
+from tickit_devices.zebra._common import default_filler, mux_types, param_types, BlockConfig
+from tickit_devices.zebra.and_or_block import AndOrBlockConfig
 from tickit_devices.zebra.zebra import ZebraAdapter
 
 
@@ -21,7 +21,7 @@ class Zebra(ComponentConfig):
 
     name: ComponentID
     inputs: Dict[PortID, ComponentPort]
-    components: List[BlockConfig]
+    components: List[AndOrBlockConfig]
     expose: Dict[PortID, ComponentPort]
     host: str = "localhost"
     port: int = 7012

--- a/src/tickit_devices/zebra/__init__.py
+++ b/src/tickit_devices/zebra/__init__.py
@@ -1,9 +1,18 @@
+from typing import List
+
 import pydantic.v1.dataclasses
+from pydantic import Field
+from tickit.adapters.io import TcpIo
+from tickit.core.adapter import AdapterContainer
+from tickit.core.components.system_simulation import (
+    SystemSimulation,
+    SystemSimulationComponent,
+)
+from tickit.core.typedefs import ComponentID
 
-from tickit.core.components.component import Component
-from tickit.core.components.system_simulation import SystemSimulation
-
-from tickit_devices.zebra.zebra import ZebraDevice
+from tickit_devices.zebra._common import default_filler, mux_types, param_types
+from tickit_devices.zebra.and_or_block import AndOrBlockConfig, BlockConfig
+from tickit_devices.zebra.zebra import ZebraAdapter
 
 
 @pydantic.v1.dataclasses.dataclass
@@ -12,10 +21,22 @@ class Zebra(SystemSimulation):
 
     host: str = "localhost"
     port: int = 7012
+    params: dict[str, int] = Field(default_factory=default_filler(param_types))
+    muxes: dict[str, int] = Field(default_factory=default_filler(mux_types))
+    components = List[BlockConfig]
 
-    def __call__(self) -> Component:  # noqa: D102
-        return ZebraDevice(
+    def __call__(self) -> SystemSimulationComponent:
+        andor_blocks = [
+            AndOrBlockConfig(name=ComponentID(f"{ANDOR}{num}"), params=self.params)
+            for ANDOR in {"AND", "OR"}
+            for num in range(4)
+        ]
+        return SystemSimulationComponent(
+            adapter=AdapterContainer(
+                adapter=ZebraAdapter(params=self.params, muxes=self.muxes),
+                io=TcpIo(host=self.host, port=self.port),
+            ),
+            components=andor_blocks,
+            expose=self.expose,
             name=self.name,
-            host=self.host,
-            port=self.port,
         )

--- a/src/tickit_devices/zebra/_common.py
+++ b/src/tickit_devices/zebra/_common.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import pydantic
-from tickit.core.components.component import BaseComponent, ComponentConfig
+from tickit.core.components.component import ComponentConfig
 from tickit.core.device import Device
 from tickit.core.typedefs import SimTime
 from typing_extensions import get_type_hints
@@ -212,7 +212,6 @@ class Block(Device, ABC):
 
 @pydantic.v1.dataclasses.dataclass
 class BlockConfig(ComponentConfig, ABC):
-
     def __call__(self) -> Block:
         """Create a block"""
         ...

--- a/src/tickit_devices/zebra/_common.py
+++ b/src/tickit_devices/zebra/_common.py
@@ -3,7 +3,9 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
-from tickit.core.components.component import BaseComponent
+import pydantic
+from tickit.core.components.component import BaseComponent, ComponentConfig
+from tickit.core.device import Device
 from tickit.core.typedefs import SimTime
 from typing_extensions import get_type_hints
 
@@ -197,14 +199,23 @@ mux_types = {name: t for name, t in register_types.items() if isinstance(t, Mux)
 
 
 @dataclass
-class Block(BaseComponent, ABC):
-    params: Dict[str, int]
+class Block(Device, ABC):
+    name: str
+    params: Dict[str, int] = None
 
     @property
     def num(self):
         match = re.search(r"\d*$", self.name)
         assert match, f"No trailing number in {self.name}"
         return int(match.group())
+
+
+@pydantic.v1.dataclasses.dataclass
+class BlockConfig(ComponentConfig, ABC):
+
+    def __call__(self) -> Block:
+        """Create a block"""
+        ...
 
 
 def default_filler(typed_dict_type) -> Callable[[], Any]:

--- a/src/tickit_devices/zebra/_common.py
+++ b/src/tickit_devices/zebra/_common.py
@@ -1,0 +1,234 @@
+import re
+from abc import ABC
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from tickit.core.components.component import BaseComponent
+from tickit.core.typedefs import SimTime
+from typing_extensions import get_type_hints
+
+
+@dataclass
+class Param:
+    reg: int
+    blocks: List[str]
+
+
+@dataclass
+class Mux:
+    reg: int
+    block: Optional[str] = None
+
+
+DIVS = [f"DIV{i}" for i in range(1, 5)]
+PULSES = [f"PULSE{i}" for i in range(1, 5)]
+GATES = [f"GATE{i}" for i in range(1, 5)]
+
+register_types: Dict[str, Union[Param, Mux]] = dict(
+    AND1_INV=Param(0x00, ["AND1"]),
+    AND2_INV=Param(0x01, ["AND2"]),
+    AND3_INV=Param(0x02, ["AND3"]),
+    AND4_INV=Param(0x03, ["AND4"]),
+    AND1_ENA=Param(0x04, ["AND1"]),
+    AND2_ENA=Param(0x05, ["AND2"]),
+    AND3_ENA=Param(0x06, ["AND3"]),
+    AND4_ENA=Param(0x07, ["AND4"]),
+    AND1_INP1=Mux(0x08, "AND1"),
+    AND1_INP2=Mux(0x09, "AND1"),
+    AND1_INP3=Mux(0x0A, "AND1"),
+    AND1_INP4=Mux(0x0B, "AND1"),
+    AND2_INP1=Mux(0x0C, "AND2"),
+    AND2_INP2=Mux(0x0D, "AND2"),
+    AND2_INP3=Mux(0x0E, "AND2"),
+    AND2_INP4=Mux(0x0F, "AND2"),
+    AND3_INP1=Mux(0x10, "AND3"),
+    AND3_INP2=Mux(0x11, "AND3"),
+    AND3_INP3=Mux(0x12, "AND3"),
+    AND3_INP4=Mux(0x13, "AND3"),
+    AND4_INP1=Mux(0x14, "AND4"),
+    AND4_INP2=Mux(0x15, "AND4"),
+    AND4_INP3=Mux(0x16, "AND4"),
+    AND4_INP4=Mux(0x17, "AND4"),
+    OR1_INV=Param(0x18, ["OR1"]),
+    OR2_INV=Param(0x19, ["OR2"]),
+    OR3_INV=Param(0x1A, ["OR3"]),
+    OR4_INV=Param(0x1B, ["OR4"]),
+    OR1_ENA=Param(0x1C, ["OR1"]),
+    OR2_ENA=Param(0x1D, ["OR2"]),
+    OR3_ENA=Param(0x1E, ["OR3"]),
+    OR4_ENA=Param(0x1F, ["OR4"]),
+    OR1_INP1=Mux(0x20, "OR1"),
+    OR1_INP2=Mux(0x21, "OR1"),
+    OR1_INP3=Mux(0x22, "OR1"),
+    OR1_INP4=Mux(0x23, "OR1"),
+    OR2_INP1=Mux(0x24, "OR2"),
+    OR2_INP2=Mux(0x25, "OR2"),
+    OR2_INP3=Mux(0x26, "OR2"),
+    OR2_INP4=Mux(0x27, "OR2"),
+    OR3_INP1=Mux(0x28, "OR3"),
+    OR3_INP2=Mux(0x29, "OR3"),
+    OR3_INP3=Mux(0x2A, "OR3"),
+    OR3_INP4=Mux(0x2B, "OR3"),
+    OR4_INP1=Mux(0x2C, "OR4"),
+    OR4_INP2=Mux(0x2D, "OR4"),
+    OR4_INP3=Mux(0x2E, "OR4"),
+    OR4_INP4=Mux(0x2F, "OR4"),
+    GATE1_INP1=Mux(0x30, "GATE1"),
+    GATE2_INP1=Mux(0x31, "GATE2"),
+    GATE3_INP1=Mux(0x32, "GATE3"),
+    GATE4_INP1=Mux(0x33, "GATE4"),
+    GATE1_INP2=Mux(0x34, "GATE1"),
+    GATE2_INP2=Mux(0x35, "GATE2"),
+    GATE3_INP2=Mux(0x36, "GATE3"),
+    GATE4_INP2=Mux(0x37, "GATE4"),
+    DIV1_DIVLO=Param(0x38, ["DIV1"]),
+    DIV1_DIVHI=Param(0x39, ["DIV1"]),
+    DIV2_DIVLO=Param(0x3A, ["DIV2"]),
+    DIV2_DIVHI=Param(0x3B, ["DIV2"]),
+    DIV3_DIVLO=Param(0x3C, ["DIV3"]),
+    DIV3_DIVHI=Param(0x3D, ["DIV3"]),
+    DIV4_DIVLO=Param(0x3E, ["DIV4"]),
+    DIV4_DIVHI=Param(0x3F, ["DIV4"]),
+    DIV1_INP=Mux(0x40, "DIV1"),
+    DIV2_INP=Mux(0x41, "DIV2"),
+    DIV3_INP=Mux(0x42, "DIV3"),
+    DIV4_INP=Mux(0x43, "DIV4"),
+    PULSE1_DLY=Param(0x44, ["PULSE1"]),
+    PULSE2_DLY=Param(0x45, ["PULSE2"]),
+    PULSE3_DLY=Param(0x46, ["PULSE3"]),
+    PULSE4_DLY=Param(0x47, ["PULSE4"]),
+    PULSE1_WID=Param(0x48, ["PULSE1"]),
+    PULSE2_WID=Param(0x49, ["PULSE2"]),
+    PULSE3_WID=Param(0x4A, ["PULSE3"]),
+    PULSE4_WID=Param(0x4B, ["PULSE4"]),
+    PULSE1_PRE=Param(0x4C, ["PULSE1"]),
+    PULSE2_PRE=Param(0x4D, ["PULSE2"]),
+    PULSE3_PRE=Param(0x4E, ["PULSE3"]),
+    PULSE4_PRE=Param(0x4F, ["PULSE4"]),
+    PULSE1_INP=Mux(0x50, "PULSE1"),
+    PULSE2_INP=Mux(0x51, "PULSE2"),
+    PULSE3_INP=Mux(0x52, "PULSE3"),
+    PULSE4_INP=Mux(0x53, "PULSE4"),
+    POLARITY=Param(0x54, GATES + DIVS + PULSES),
+    QUAD_DIR=Param(0x55, ["QUAD"]),
+    QUAD_STEP=Param(0x56, ["QUAD"]),
+    PC_ARM_INP=Mux(0x57, "PC"),
+    PC_GATE_INP=Mux(0x58, "PC"),
+    PC_PULSE_INP=Mux(0x59, "PC"),
+    OUT1_TTL=Mux(0x60),
+    OUT1_NIM=Mux(0x61),
+    OUT1_LVDS=Mux(0x62),
+    OUT2_TTL=Mux(0x63),
+    OUT2_NIM=Mux(0x64),
+    OUT2_LVDS=Mux(0x65),
+    OUT3_TTL=Mux(0x66),
+    OUT3_OC=Mux(0x67),
+    OUT3_LVDS=Mux(0x68),
+    OUT4_TTL=Mux(0x69),
+    OUT4_NIM=Mux(0x6A),
+    OUT4_PECL=Mux(0x6B),
+    OUT5_ENCA=Mux(0x6C),
+    OUT5_ENCB=Mux(0x6D),
+    OUT5_ENCZ=Mux(0x6E),
+    OUT5_CONN=Mux(0x6F),
+    OUT6_ENCA=Mux(0x70),
+    OUT6_ENCB=Mux(0x71),
+    OUT6_ENCZ=Mux(0x72),
+    OUT6_CONN=Mux(0x73),
+    OUT7_ENCA=Mux(0x74),
+    OUT7_ENCB=Mux(0x75),
+    OUT7_ENCZ=Mux(0x76),
+    OUT7_CONN=Mux(0x77),
+    OUT8_ENCA=Mux(0x78),
+    OUT8_ENCB=Mux(0x79),
+    OUT8_ENCZ=Mux(0x7A),
+    OUT8_CONN=Mux(0x7B),
+    DIV_FIRST=Param(0x7C, DIVS),
+    SYS_RESET=Param(0x7E, []),
+    SOFT_IN=Param(0x7F, ["SOFT"]),
+    POS1_SETLO=Param(0x80, ["POS1"]),
+    POS1_SETHI=Param(0x81, ["POS1"]),
+    POS2_SETLO=Param(0x82, ["POS2"]),
+    POS2_SETHI=Param(0x83, ["POS2"]),
+    POS3_SETLO=Param(0x84, ["POS3"]),
+    POS3_SETHI=Param(0x85, ["POS3"]),
+    POS4_SETLO=Param(0x86, ["POS4"]),
+    POS4_SETHI=Param(0x87, ["POS4"]),
+    PC_ENC=Param(0x88, ["PC"]),
+    PC_TSPRE=Param(0x89, ["PC"]),
+    PC_ARM_SEL=Param(0x8A, ["PC"]),
+    PC_ARM=Param(0x8B, ["PC"]),
+    PC_DISARM=Param(0x8C, ["PC"]),
+    PC_GATE_SEL=Param(0x8D, ["PC"]),
+    PC_GATE_STARTLO=Param(0x8E, ["PC"]),
+    PC_GATE_STARTHI=Param(0x8F, ["PC"]),
+    PC_GATE_WIDLO=Param(0x90, ["PC"]),
+    PC_GATE_WIDHI=Param(0x91, ["PC"]),
+    PC_GATE_NGATELO=Param(0x92, ["PC"]),
+    PC_GATE_NGATEHI=Param(0x93, ["PC"]),
+    PC_GATE_STEPLO=Param(0x94, ["PC"]),
+    PC_GATE_STEPHI=Param(0x95, ["PC"]),
+    PC_PULSE_SEL=Param(0x96, ["PC"]),
+    PC_PULSE_STARTLO=Param(0x97, ["PC"]),
+    PC_PULSE_STARTHI=Param(0x98, ["PC"]),
+    PC_PULSE_WIDLO=Param(0x99, ["PC"]),
+    PC_PULSE_WIDHI=Param(0x9A, ["PC"]),
+    PC_PULSE_STEPLO=Param(0x9B, ["PC"]),
+    PC_PULSE_STEPHI=Param(0x9C, ["PC"]),
+    PC_PULSE_MAXLO=Param(0x9D, ["PC"]),
+    PC_PULSE_MAXHI=Param(0x9E, ["PC"]),
+    PC_BIT_CAP=Param(0x9F, ["PC"]),
+    PC_DIR=Param(0xA0, ["PC"]),
+    PC_PULSE_DLYLO=Param(0xA1, ["PC"]),
+    PC_PULSE_DLYHI=Param(0xA2, ["PC"]),
+    SYS_VER=Param(0xF0, []),
+    SYS_STATERR=Param(0xF1, []),
+    SYS_STAT1LO=Param(0xF2, []),
+    SYS_STAT1HI=Param(0xF3, []),
+    SYS_STAT2LO=Param(0xF4, []),
+    SYS_STAT2HI=Param(0xF5, []),
+    PC_NUM_CAPLO=Param(0xF6, []),
+    PC_NUM_CAPHI=Param(0xF7, []),
+)
+
+register_names = {reg.reg: name for name, reg in register_types.items()}
+param_types = {name: t for name, t in register_types.items() if isinstance(t, Param)}
+mux_types = {name: t for name, t in register_types.items() if isinstance(t, Mux)}
+
+
+@dataclass
+class Block(BaseComponent, ABC):
+    params: Dict[str, int]
+
+    @property
+    def num(self):
+        match = re.search(r"\d*$", self.name)
+        assert match, f"No trailing number in {self.name}"
+        return int(match.group())
+
+
+def default_filler(typed_dict_type) -> Callable[[], Any]:
+    def make_default():
+        return {name: typ() for name, typ in get_type_hints(typed_dict_type).items()}
+
+    return make_default
+
+
+def extract_bit(registers: Dict[str, int], key: str, shift: int) -> bool:
+    return bool((registers[key] >> shift) & 1)
+
+
+def clear_bit(registers: Dict[str, int], key: str, shift: int):
+    registers[key] &= ~(1 << shift)
+
+
+def set_bit(registers: Dict[str, int], key: str, shift: int):
+    registers[key] |= 1 << shift
+
+
+def rising(old: bool, new: bool) -> bool:
+    return new and not old
+
+
+def in_ns(ticks: Optional[int]) -> Optional[SimTime]:
+    return None if ticks is None else SimTime(ticks * 20)

--- a/src/tickit_devices/zebra/_common.py
+++ b/src/tickit_devices/zebra/_common.py
@@ -1,5 +1,5 @@
 import re
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -201,7 +201,7 @@ mux_types = {name: t for name, t in register_types.items() if isinstance(t, Mux)
 @dataclass
 class Block(Device, ABC):
     name: str
-    params: Dict[str, int] = None
+    params: Dict[str, int]
 
     @property
     def num(self):
@@ -212,6 +212,7 @@ class Block(Device, ABC):
 
 @pydantic.v1.dataclasses.dataclass
 class BlockConfig(ComponentConfig, ABC):
+    @abstractmethod
     def __call__(self) -> Block:
         """Create a block"""
         ...

--- a/src/tickit_devices/zebra/_common.py
+++ b/src/tickit_devices/zebra/_common.py
@@ -201,13 +201,21 @@ mux_types = {name: t for name, t in register_types.items() if isinstance(t, Mux)
 @dataclass
 class Block(Device, ABC):
     name: str
-    params: Dict[str, int]
+    params: Optional[Dict[str, int]] = None
 
     @property
     def num(self):
         match = re.search(r"\d*$", self.name)
         assert match, f"No trailing number in {self.name}"
         return int(match.group())
+
+    @abstractmethod
+    def read_mux(self, register: str) -> int:
+        ...
+
+    @abstractmethod
+    def set_mux(self, register: str, value: int) -> int:
+        ...
 
 
 @pydantic.v1.dataclasses.dataclass

--- a/src/tickit_devices/zebra/and_or_block.py
+++ b/src/tickit_devices/zebra/and_or_block.py
@@ -11,7 +11,13 @@ from tickit_devices.zebra._common import Block, BlockConfig, extract_bit
 
 
 class AndOrBlock(Block):
-    """Represents an AND or OR gate"""
+    """
+    Represents an AND or OR gate with 4 inputs.
+    If an input is not enabled, it will always be considered False,
+    unless it is also inverted.
+    """
+
+    last_input: "AndOrBlock.Inputs"
 
     class Inputs(TypedDict):
         INP1: bool
@@ -23,14 +29,38 @@ class AndOrBlock(Block):
         OUT: bool
 
     def _get_input(self, inputs: Dict[str, bool], i: int) -> bool:
+        if not self.params:
+            raise ValueError
         enabled = extract_bit(self.params, f"{self.name}_ENA", i)
         inverted = extract_bit(self.params, f"{self.name}_INV", i)
         return enabled & inputs.get(f"INP{i + 1}", False) ^ inverted
+
+    def read_mux(self, inp: str) -> int:
+        # TODO: Is there a better way of getting the input from the adapter?
+        return int(self.last_input[inp] if self.last_input else False)  # type: ignore
+
+    def set_mux(self, register: str, value: int) -> int:
+        # TODO: Does this do everything it needs to?
+        self.update(
+            SimTime(0),
+            AndOrBlock.Inputs(
+                **self.last_input
+                or {
+                    "INP1": False,
+                    "INP2": False,
+                    "INP3": False,
+                    "INP4": False,
+                },
+                **{register: bool(value)},
+            ),
+        )
+        return value
 
     def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
         op = and_ if self.name.startswith("AND") else or_
         get_input = partial(self._get_input, inputs)
         outputs = self.Outputs(OUT=reduce(op, map(get_input, range(4))))
+        self.last_input = inputs
         return DeviceUpdate(outputs, call_at=None)  # type: ignore
 
 

--- a/src/tickit_devices/zebra/and_or_block.py
+++ b/src/tickit_devices/zebra/and_or_block.py
@@ -1,0 +1,59 @@
+from abc import ABC
+from dataclasses import dataclass
+from functools import partial, reduce
+from operator import and_, or_
+from typing import Dict
+
+from tickit.core.components.component import ComponentConfig
+from tickit.core.device import DeviceUpdate
+from tickit.core.typedefs import Changes, ComponentID, SimTime
+from typing_extensions import TypedDict
+
+from tickit_devices.zebra._common import Block, extract_bit
+
+
+class Inputs(TypedDict):
+    INP1: bool
+    INP2: bool
+    INP3: bool
+    INP4: bool
+
+
+class Outputs(TypedDict):
+    OUT: bool
+
+
+class AndOrBlock(Block):
+    """Represents an AND or OR gate"""
+
+    async def stop_component(self) -> None:
+        pass
+
+    def _get_input(self, inputs: Dict[str, bool], i: int) -> bool:
+        enabled = extract_bit(self.params, f"{self.name}_ENA", i)
+        inverted = extract_bit(self.params, f"{self.name}_INV", i)
+        return enabled & inputs[f"INP{i+1}"] ^ inverted
+
+    def on_tick(self, time: SimTime, changes: Changes) -> DeviceUpdate[Outputs]:
+        op = and_ if self.name.startswith("AND") else or_
+        get_input = partial(self._get_input, changes)
+        outputs = Outputs(OUT=reduce(op, map(get_input, range(4))))
+        return DeviceUpdate(outputs, call_at=None)
+
+
+@dataclass
+class BlockConfig(ComponentConfig, ABC):
+    params: dict[str, int]
+
+    def __init__(self, name: ComponentID, params: dict[str, int]):
+        super().__init__(name, inputs={})
+        self.params = params
+
+
+@dataclass
+class AndOrBlockConfig(BlockConfig):
+    def __init__(self, name: ComponentID, params: dict[str, int]):
+        super().__init__(name, params)
+
+    def __call__(self) -> AndOrBlock:
+        return AndOrBlock(self.name, self.params)

--- a/src/tickit_devices/zebra/and_or_block.py
+++ b/src/tickit_devices/zebra/and_or_block.py
@@ -1,12 +1,12 @@
-from abc import ABC
-from dataclasses import dataclass
+from abc import ABC, abstractmethod
 from functools import partial, reduce
 from operator import and_, or_
 from typing import Dict, TypedDict
 
+import pydantic.v1.dataclasses
 from tickit.core.components.component import ComponentConfig
-from tickit.core.device import DeviceUpdate, InMap, OutMap
-from tickit.core.typedefs import Changes, ComponentID, SimTime
+from tickit.core.device import DeviceUpdate
+from tickit.core.typedefs import Changes, SimTime
 
 from tickit_devices.zebra._common import Block, extract_bit
 
@@ -35,18 +35,22 @@ class AndOrBlock(Block):
         op = and_ if self.name.startswith("AND") else or_
         get_input = partial(self._get_input, changes)
         outputs = self.Outputs(OUT=reduce(op, map(get_input, range(4))))
-        return DeviceUpdate(outputs, call_at=None)
+        return DeviceUpdate(outputs, call_at=None)  # type: ignore
 
 
-@dataclass
+@pydantic.v1.dataclasses.dataclass
 class BlockConfig(ComponentConfig, ABC):
-    params: dict[str, int]
 
-    def __init__(self, name: ComponentID, params: dict[str, int]):
-        super().__init__(name, inputs={})
-        self.params = params
+    @abstractmethod
+    def __call__(self, params: Dict[str, int] = None) -> Block:
+        """Create the component from the given config with the shared params"""
+        ...
 
 
 class AndOrBlockConfig(BlockConfig):
-    def __call__(self) -> AndOrBlock:
-        return AndOrBlock(self.name, self.params)
+
+    def __call__(self, params: Dict[str, int] = None) -> Block:
+        """Create the component from the given config with the shared params"""
+        if params is None:
+            raise TypeError
+        return AndOrBlock(name=self.name, params=params)

--- a/src/tickit_devices/zebra/and_or_block.py
+++ b/src/tickit_devices/zebra/and_or_block.py
@@ -2,29 +2,26 @@ from abc import ABC
 from dataclasses import dataclass
 from functools import partial, reduce
 from operator import and_, or_
-from typing import Dict
+from typing import Dict, TypedDict
 
 from tickit.core.components.component import ComponentConfig
-from tickit.core.device import DeviceUpdate
+from tickit.core.device import DeviceUpdate, InMap, OutMap
 from tickit.core.typedefs import Changes, ComponentID, SimTime
-from typing_extensions import TypedDict
 
 from tickit_devices.zebra._common import Block, extract_bit
 
 
-class Inputs(TypedDict):
-    INP1: bool
-    INP2: bool
-    INP3: bool
-    INP4: bool
-
-
-class Outputs(TypedDict):
-    OUT: bool
-
-
 class AndOrBlock(Block):
     """Represents an AND or OR gate"""
+
+    class Inputs(TypedDict):
+        INP1: bool
+        INP2: bool
+        INP3: bool
+        INP4: bool
+
+    class Outputs(TypedDict):
+        OUT: bool
 
     async def stop_component(self) -> None:
         pass
@@ -32,12 +29,12 @@ class AndOrBlock(Block):
     def _get_input(self, inputs: Dict[str, bool], i: int) -> bool:
         enabled = extract_bit(self.params, f"{self.name}_ENA", i)
         inverted = extract_bit(self.params, f"{self.name}_INV", i)
-        return enabled & inputs[f"INP{i+1}"] ^ inverted
+        return enabled & inputs[f"INP{i + 1}"] ^ inverted
 
     def on_tick(self, time: SimTime, changes: Changes) -> DeviceUpdate[Outputs]:
         op = and_ if self.name.startswith("AND") else or_
         get_input = partial(self._get_input, changes)
-        outputs = Outputs(OUT=reduce(op, map(get_input, range(4))))
+        outputs = self.Outputs(OUT=reduce(op, map(get_input, range(4))))
         return DeviceUpdate(outputs, call_at=None)
 
 
@@ -50,10 +47,6 @@ class BlockConfig(ComponentConfig, ABC):
         self.params = params
 
 
-@dataclass
 class AndOrBlockConfig(BlockConfig):
-    def __init__(self, name: ComponentID, params: dict[str, int]):
-        super().__init__(name, params)
-
     def __call__(self) -> AndOrBlock:
         return AndOrBlock(self.name, self.params)

--- a/src/tickit_devices/zebra/and_or_block.py
+++ b/src/tickit_devices/zebra/and_or_block.py
@@ -7,7 +7,7 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.device import DeviceUpdate
 from tickit.core.typedefs import SimTime
 
-from tickit_devices.zebra._common import Block, extract_bit, BlockConfig
+from tickit_devices.zebra._common import Block, BlockConfig, extract_bit
 
 
 class AndOrBlock(Block):
@@ -36,6 +36,5 @@ class AndOrBlock(Block):
 
 @pydantic.v1.dataclasses.dataclass
 class AndOrBlockConfig(BlockConfig):
-
     def __call__(self) -> DeviceSimulation:
         return DeviceSimulation(name=self.name, device=AndOrBlock(name=self.name))

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -1,19 +1,22 @@
 import asyncio
-import dataclasses
 from typing import Dict
 
 from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.system import BaseSystemSimulationAdapter
+from tickit.core.typedefs import ComponentID
 
-from tickit_devices.zebra._common import Block, param_types, register_names
+from tickit_devices.zebra._common import param_types, register_names, Block
 
 
-@dataclasses.dataclass
 class ZebraAdapter(BaseSystemSimulationAdapter):
-    _components: Dict[str, Block]
+    _components: Dict[ComponentID, Block]
     params: dict[str, int]
     muxes: dict[str, int]
     """network adapter for zebra system simulation"""
+
+    def __init__(self, params: dict[str, int], muxes: dict[str, int]):
+        self.params = params
+        self.muxes = muxes
 
     @RegexCommand(rb"W([0-9A-F]{2})([0-9A-F]{4})\n", interrupt=True)
     async def set_reg(self, reg: str, value: str) -> bytes:

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -1,67 +1,43 @@
+import asyncio
+import dataclasses
 from typing import Dict
 
-from tickit.adapters.composed import ComposedAdapter
-from tickit.adapters.interpreters.command import RegexCommand
-from tickit.adapters.servers.tcp import TcpServer
-from tickit.core.components.system_simulation import SystemSimulationComponent
-from tickit.core.typedefs import ComponentID
+from tickit.adapters.specifications import RegexCommand
+from tickit.adapters.system import BaseSystemSimulationAdapter
 
-from tickit_devices.zebra._common import Block, mux_types, param_types, register_names
-from tickit_devices.zebra.and_or_block import AndOrBlockConfig
+from tickit_devices.zebra._common import Block, param_types, register_names
 
 
-class ZebraDevice(SystemSimulationComponent):
-    blocks = Dict[str, Block]
-    params: Dict[str, int]
-    muxes: Dict[str, int]
-    server: TcpServer
-
-    def __init__(self, name: ComponentID, host: str = "localhost", port: int = 7012):
-        self.params = {param: 0 for param in param_types}
-        self.muxes = {mux: 0 for mux in mux_types}
-        self.blocks = {
-            block.name: block
-            for block in [
-                AndOrBlockConfig(ComponentID(f"{ANDOR}{NUM + 1}"), self.params)
-                for ANDOR in {"AND", "OR"}
-                for NUM in range(4)
-            ]
-        }
-        self.server = TcpServer(host, port)
-        super().__init__(
-            name=name,
-            expose={},
-            components=[block for block in self.blocks.values()],
-        )
-
-    def set_reg(self, reg: int, value: int):
-        reg_name = register_names[reg]
-        if reg_name in self.params:
-            self.params[reg_name] = value
-            for block_name in param_types[reg_name].blocks:
-                self.components[block_name].raise_interrupt()
-        else:
-            self.muxes[reg_name] = value
-
-    def get_reg(self, reg: int) -> int:
-        reg_name = register_names[reg]
-        try:
-            return self.params[reg_name]
-        except KeyError:
-            return self.muxes[reg_name]
-
-
-class ZebraAdapter(ComposedAdapter[bytes, ZebraDevice]):
+@dataclasses.dataclass
+class ZebraAdapter(BaseSystemSimulationAdapter):
+    _components: Dict[str, Block]
+    params: dict[str, int]
+    muxes: dict[str, int]
     """network adapter for zebra system simulation"""
 
     @RegexCommand(rb"W([0-9A-F]{2})([0-9A-F]{4})\n", interrupt=True)
     async def set_reg(self, reg: str, value: str) -> bytes:
         reg_int, value_int = int(reg, base=16), int(value, base=16)
-        self.device.set_reg(reg_int, value_int)
+        reg_name = register_names[reg_int]
+
+        if reg_name in self.params:
+            self.params[reg_name] = value_int
+
+            async with asyncio.TaskGroup() as tg:
+                for block_name in param_types[reg_name].blocks:
+                    tg.create_task(self._components[block_name].raise_interrupt())
+
+        else:
+            self.muxes[reg_name] = value_int
+
         return b"W%02XOK" % reg_int
 
     @RegexCommand(rb"R([0-9A-F]{2})\n")
     async def get_reg(self, reg: str) -> bytes:
         reg_int = int(reg, base=16)
-        value_int = self.device.get_reg(reg_int)
+        reg_name = register_names[reg_int]
+        try:
+            value_int = self.params[reg_name]
+        except KeyError:
+            value_int = self.muxes[reg_name]
         return b"R%02X%04XOK" % (reg_int, value_int)

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.system import BaseSystemSimulationAdapter
@@ -7,25 +7,49 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.management.event_router import InverseWiring, Wiring
 from tickit.core.typedefs import ComponentID
 
-from tickit_devices.zebra._common import param_types, register_names
+from tickit_devices.zebra._common import (
+    Block,
+    Mux,
+    mux_types,
+    param_types,
+    register_names,
+)
 
 
 class ZebraAdapter(BaseSystemSimulationAdapter):
     _components: Dict[ComponentID, DeviceSimulation]
     params: dict[str, int]
-    muxes: dict[str, int]
-    """network adapter for zebra system simulation"""
+    """
+    Network adapter for a Zebra system simulation, which operates a TCP server for
+    reading and writing params (configuration of the internal blocks) and muxes
+    (state of the internal blocks).
 
-    def __init__(self, params: dict[str, int], muxes: dict[str, int]):
+    Attempting to set or read muxes from blocks that are not instantiated returns 0.
+
+    Params that are currently supported:
+    - For AND/OR gates N=1,2,3,4, the following (default 0) may be set
+    to Σ2**M where M is each input (1,2,3,4) for which the behaviour is desired.
+    {AND|OR}{N}_INV: Inverts input(s) M
+    {AND|OR}{N}_ENA: Enables input(s) M
+
+    Muxes that are currently supported:
+    The following values may also be read from or set on the register of the blocks:
+    - For AND/OR gates N=1,2,3,4, for inputs M=1,2,3,4
+    {AND|OR}{N}_INP{M}
+    """
+
+    def __init__(self, params: dict[str, int]):
         self.params = params
-        self.muxes = muxes
 
     def setup_adapter(
         self,
         components: Dict[ComponentID, DeviceSimulation],
         wiring: Union[Wiring, InverseWiring],
     ) -> None:
-        """Provides the components and wiring of a SystemSimulationComponent."""
+        """
+        Sets the shared configuration/"params" between the Zebra and its components
+        then instantiates them.
+        """
         for block in components.values():
             block.device.params = self.params
         super().setup_adapter(components, wiring)
@@ -44,7 +68,7 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
                 )
 
         else:
-            self.muxes[reg_name] = value_int
+            self._set_mux(reg_name, value_int)
 
         return b"W%02XOK" % reg_int
 
@@ -55,5 +79,29 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
         try:
             value_int = self.params[reg_name]
         except KeyError:
-            value_int = self.muxes[reg_name]
+            value_int = self._read_mux(reg_name)
         return b"R%02X%04XOK" % (reg_int, value_int)
+
+    def _read_mux(self, reg_name: str) -> int:
+        block = self._get_mux_block(reg_name)
+        if block:
+            return block.read_mux(reg_name.removeprefix(f"{block.name}_"))
+        return 0
+
+    def _set_mux(self, reg_name: str, value: int) -> int:
+        block = self._get_mux_block(reg_name)
+        if block:
+            return block.set_mux(reg_name.removeprefix(f"{block.name}_"), value)
+        return 0
+
+    def _get_mux_block(self, reg_name: str) -> Optional[Block]:
+        register: Mux = mux_types[reg_name]
+        if not register:
+            return None
+        block_name = register.block
+        if not block_name:
+            return None
+        block = self._components.get(ComponentID(block_name))
+        if not isinstance(block, Block):
+            return None
+        return block

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -38,9 +38,10 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
         if reg_name in self.params:
             self.params[reg_name] = value_int
 
-            async with asyncio.TaskGroup() as tg:
-                for block_name in param_types[reg_name].blocks:
-                    tg.create_task(self._components[block_name].raise_interrupt())
+            for block_name in param_types[reg_name].blocks:
+                await asyncio.create_task(
+                    self._components[block_name].raise_interrupt()
+                )
 
         else:
             self.muxes[reg_name] = value_int

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -1,0 +1,67 @@
+from typing import Dict
+
+from tickit.adapters.composed import ComposedAdapter
+from tickit.adapters.interpreters.command import RegexCommand
+from tickit.adapters.servers.tcp import TcpServer
+from tickit.core.components.system_simulation import SystemSimulationComponent
+from tickit.core.typedefs import ComponentID
+
+from tickit_devices.zebra._common import Block, mux_types, param_types, register_names
+from tickit_devices.zebra.and_or_block import AndOrBlockConfig
+
+
+class ZebraDevice(SystemSimulationComponent):
+    blocks = Dict[str, Block]
+    params: Dict[str, int]
+    muxes: Dict[str, int]
+    server: TcpServer
+
+    def __init__(self, name: ComponentID, host: str = "localhost", port: int = 7012):
+        self.params = {param: 0 for param in param_types}
+        self.muxes = {mux: 0 for mux in mux_types}
+        self.blocks = {
+            block.name: block
+            for block in [
+                AndOrBlockConfig(ComponentID(f"{ANDOR}{NUM + 1}"), self.params)
+                for ANDOR in {"AND", "OR"}
+                for NUM in range(4)
+            ]
+        }
+        self.server = TcpServer(host, port)
+        super().__init__(
+            name=name,
+            expose={},
+            components=[block for block in self.blocks.values()],
+        )
+
+    def set_reg(self, reg: int, value: int):
+        reg_name = register_names[reg]
+        if reg_name in self.params:
+            self.params[reg_name] = value
+            for block_name in param_types[reg_name].blocks:
+                self.components[block_name].raise_interrupt()
+        else:
+            self.muxes[reg_name] = value
+
+    def get_reg(self, reg: int) -> int:
+        reg_name = register_names[reg]
+        try:
+            return self.params[reg_name]
+        except KeyError:
+            return self.muxes[reg_name]
+
+
+class ZebraAdapter(ComposedAdapter[bytes, ZebraDevice]):
+    """network adapter for zebra system simulation"""
+
+    @RegexCommand(rb"W([0-9A-F]{2})([0-9A-F]{4})\n", interrupt=True)
+    async def set_reg(self, reg: str, value: str) -> bytes:
+        reg_int, value_int = int(reg, base=16), int(value, base=16)
+        self.device.set_reg(reg_int, value_int)
+        return b"W%02XOK" % reg_int
+
+    @RegexCommand(rb"R([0-9A-F]{2})\n")
+    async def get_reg(self, reg: str) -> bytes:
+        reg_int = int(reg, base=16)
+        value_int = self.device.get_reg(reg_int)
+        return b"R%02X%04XOK" % (reg_int, value_int)

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -7,7 +7,7 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.management.event_router import InverseWiring, Wiring
 from tickit.core.typedefs import ComponentID
 
-from tickit_devices.zebra._common import param_types, register_names, Block
+from tickit_devices.zebra._common import param_types, register_names
 
 
 class ZebraAdapter(BaseSystemSimulationAdapter):

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.system import BaseSystemSimulationAdapter
@@ -7,13 +7,7 @@ from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.management.event_router import InverseWiring, Wiring
 from tickit.core.typedefs import ComponentID
 
-from tickit_devices.zebra._common import (
-    Block,
-    Mux,
-    mux_types,
-    param_types,
-    register_names,
-)
+from tickit_devices.zebra._common import param_types, register_names
 
 
 class ZebraAdapter(BaseSystemSimulationAdapter):
@@ -21,21 +15,18 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
     params: dict[str, int]
     """
     Network adapter for a Zebra system simulation, which operates a TCP server for
-    reading and writing params (configuration of the internal blocks) and muxes
-    (state of the internal blocks).
+    reading and setting configuration of blocks and internal wiring mapping.
+    N.B. Reading and setting internal wiring is not currently supported,and all
+    "mux" related queries will return as though successful but not operate.
 
-    Attempting to set or read muxes from blocks that are not instantiated returns 0.
+    See documentation for the Zebra:
+    `https://github.com/dls-controls/zebra/blob/master/documentation/TDI-CTRL-TNO-042-Zebra-Manual.pdf`
 
-    Params that are currently supported:
+    Configuration that is currently supported:
     - For AND/OR gates N=1,2,3,4, the following (default 0) may be set
     to Σ2**M where M is each input (1,2,3,4) for which the behaviour is desired.
     {AND|OR}{N}_INV: Inverts input(s) M
     {AND|OR}{N}_ENA: Enables input(s) M
-
-    Muxes that are currently supported:
-    The following values may also be read from or set on the register of the blocks:
-    - For AND/OR gates N=1,2,3,4, for inputs M=1,2,3,4
-    {AND|OR}{N}_INP{M}
     """
 
     def __init__(self, params: dict[str, int]):
@@ -82,26 +73,11 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
             value_int = self._read_mux(reg_name)
         return b"R%02X%04XOK" % (reg_int, value_int)
 
-    def _read_mux(self, reg_name: str) -> int:
-        block = self._get_mux_block(reg_name)
-        if block:
-            return block.read_mux(reg_name.removeprefix(f"{block.name}_"))
+    def _read_mux(self, reg_name: str) -> int:  # type: ignore
+        # TODO: Support reading Muxes: map internal wiring into Mux values
         return 0
 
-    def _set_mux(self, reg_name: str, value: int) -> int:
-        block = self._get_mux_block(reg_name)
-        if block:
-            return block.set_mux(reg_name.removeprefix(f"{block.name}_"), value)
+    def _set_mux(self, reg_name: str, value: int) -> int:  # type: ignore
+        # TODO: Support setting Muxes: map Mux value into internal wiring
+        # TODO: Support cyclic wirings involving Zebra: AND1_OUT->AND1_INP1 is valid
         return 0
-
-    def _get_mux_block(self, reg_name: str) -> Optional[Block]:
-        register: Mux = mux_types[reg_name]
-        if not register:
-            return None
-        block_name = register.block
-        if not block_name:
-            return None
-        block = self._components.get(ComponentID(block_name))
-        if not isinstance(block, Block):
-            return None
-        return block

--- a/tests/zebra/devices.py
+++ b/tests/zebra/devices.py
@@ -1,0 +1,119 @@
+from typing import TypedDict
+
+import pydantic.v1.dataclasses
+from tickit.core.components.component import ComponentConfig
+from tickit.core.device import Device, DeviceUpdate
+from tickit.core.typedefs import SimTime
+
+import logging
+from typing import TypedDict
+
+import pydantic.v1.dataclasses
+
+from tickit.core.components.component import Component, ComponentConfig
+from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.device import Device, DeviceUpdate
+from tickit.core.typedefs import SimTime
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pydantic.v1.dataclasses.dataclass
+class Counter(ComponentConfig):
+    """Simulation of simple counting device."""
+
+    def __call__(self) -> Component:  # noqa: D102
+        return DeviceSimulation(name=self.name, device=CounterDevice())
+
+
+class CounterDevice(Device):
+    """A simple device which increments a value."""
+
+    #: An empty typed mapping of input values
+    class Inputs(TypedDict):
+        ...
+
+    #: A typed mapping containing the 'value' output value
+    class Outputs(TypedDict):
+        value: int
+
+    def __init__(self, initial_value: int = 0, callback_period: int = int(1e9)) -> None:
+        """A constructor of the counter, which increments the input value.
+
+        Args:
+            initial_value (Any): The initial value of the counter.
+            callback_period (int): The simulation time callback period of the device
+                (in nanoseconds). Defaults to int(1e9).
+        """
+        self._value = initial_value
+        self.callback_period = SimTime(callback_period)
+        LOGGER.debug(f"Counter initialized with value => {self._value}")
+
+    def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
+        """The update method which produces the incremented value.
+
+        Args:
+            time (SimTime): The current simulation time (in nanoseconds).
+            inputs (State): A mapping of inputs to the device and their values.
+
+        Returns:
+            DeviceUpdate[Outputs]:
+                The produced update event which contains the incremented value, and
+                requests a callback after callback_period.
+        """
+        self._value = self._value + 1
+        LOGGER.debug(f"Counter incremented to {self._value}")
+        return DeviceUpdate(
+            CounterDevice.Outputs(value=self._value),
+            SimTime(time + self.callback_period),
+        )
+
+
+class DividingDevice(Device):
+    """
+    A toy device which turns an input number into a boolean of whether it divides into a set number.
+    """
+
+    class Inputs(TypedDict):
+        input: int
+
+    class Outputs(TypedDict):
+        output: bool
+
+    def __init__(self, denominator: int) -> None:
+        self.denominator = denominator
+
+    def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
+        output = inputs["input"] % self.denominator == 0
+        return DeviceUpdate(self.Outputs(output=output), None)
+
+
+@pydantic.v1.dataclasses.dataclass
+class DividingConfig(ComponentConfig):
+    denominator: int
+
+    def __call__(self) -> DeviceSimulation:
+        """Create the component from the given config."""
+        return DeviceSimulation(name=self.name, device=DividingDevice(denominator=self.denominator))
+
+
+class FizzBangDevice(Device):
+    class Inputs(TypedDict):
+        fizzbang: bool
+        fizz: bool
+        bang: bool
+
+    class Outputs(TypedDict):
+        output: str
+
+    def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
+        out = [k for k, v in inputs.items() if v] or ["Not Fizzbang"]
+        return DeviceUpdate(self.Outputs(output=out[0]), None)
+
+
+@pydantic.v1.dataclasses.dataclass
+class FizzBang(ComponentConfig):
+
+    def __call__(self) -> DeviceSimulation:
+        """Create the component from the given config."""
+        return DeviceSimulation(name=self.name, device=FizzBangDevice())

--- a/tests/zebra/devices.py
+++ b/tests/zebra/devices.py
@@ -102,7 +102,8 @@ class FizzBangDevice(Device):
         output: str
 
     def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
-        out = [k for k, v in inputs.items() if v] or ["Not Fizzbang"]
+        out = ["fizzbang"] if inputs["fizzbang"] else\
+            [k for k, v in inputs.items() if v] or ["Not Fizzbang"]
         return DeviceUpdate(self.Outputs(output=out[0]), None)
 
 

--- a/tests/zebra/devices.py
+++ b/tests/zebra/devices.py
@@ -1,15 +1,7 @@
-from typing import TypedDict
-
-import pydantic.v1.dataclasses
-from tickit.core.components.component import ComponentConfig
-from tickit.core.device import Device, DeviceUpdate
-from tickit.core.typedefs import SimTime
-
 import logging
 from typing import TypedDict
 
 import pydantic.v1.dataclasses
-
 from tickit.core.components.component import Component, ComponentConfig
 from tickit.core.components.device_simulation import DeviceSimulation
 from tickit.core.device import Device, DeviceUpdate
@@ -71,7 +63,8 @@ class CounterDevice(Device):
 
 class DividingDevice(Device):
     """
-    A toy device which turns an input number into a boolean of whether it divides into a set number.
+    A toy device which turns an input number into a boolean of whether it
+    divides exactly into a given denominator.
     """
 
     class Inputs(TypedDict):
@@ -94,7 +87,9 @@ class DividingConfig(ComponentConfig):
 
     def __call__(self) -> DeviceSimulation:
         """Create the component from the given config."""
-        return DeviceSimulation(name=self.name, device=DividingDevice(denominator=self.denominator))
+        return DeviceSimulation(
+            name=self.name, device=DividingDevice(denominator=self.denominator)
+        )
 
 
 class FizzBangDevice(Device):
@@ -113,7 +108,6 @@ class FizzBangDevice(Device):
 
 @pydantic.v1.dataclasses.dataclass
 class FizzBang(ComponentConfig):
-
     def __call__(self) -> DeviceSimulation:
         """Create the component from the given config."""
         return DeviceSimulation(name=self.name, device=FizzBangDevice())

--- a/tests/zebra/devices.py
+++ b/tests/zebra/devices.py
@@ -102,8 +102,11 @@ class FizzBangDevice(Device):
         output: str
 
     def update(self, time: SimTime, inputs: Inputs) -> DeviceUpdate[Outputs]:
-        out = ["fizzbang"] if inputs["fizzbang"] else\
-            [k for k, v in inputs.items() if v] or ["Not Fizzbang"]
+        out = (
+            ["fizzbang"]
+            if inputs["fizzbang"]
+            else [k for k, v in inputs.items() if v] or ["Not Fizzbang"]
+        )
         return DeviceUpdate(self.Outputs(output=out[0]), None)
 
 

--- a/tests/zebra/zebra.py
+++ b/tests/zebra/zebra.py
@@ -1,7 +1,7 @@
 import pytest
 from tickit.core.typedefs import ComponentID, SimTime
 
-from tickit_devices.zebra.and_or_block import AndOrBlockConfig
+from tickit_devices.zebra.and_or_block import AndOrBlock
 
 all_true = 15
 one_false = 14
@@ -17,10 +17,10 @@ varying_values_of_true = {all_false, one_true, one_false, all_true}
 @pytest.mark.parametrize("inverted", varying_values_of_true)
 def test_and_block_enabled_or_inverted(enabled: int, inverted: int):
     name = ComponentID("AND1")
-    params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
     mux = {f"INP{i + 1}": True for i in range(4)}
-    block = AndOrBlockConfig(name, params)()
-    out = block.on_tick(SimTime(0), mux)
+    block = AndOrBlock(name=name)
+    block.params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
+    out = block.update(SimTime(0), mux)
     assert out.outputs == {
         "OUT": enabled + inverted == all_true
     }  # All devices either enabled or inverted
@@ -30,10 +30,10 @@ def test_and_block_enabled_or_inverted(enabled: int, inverted: int):
 @pytest.mark.parametrize("inverted", varying_values_of_true)
 def test_or_block_enabled_or_inverted(enabled: int, inverted: int):
     name = ComponentID("OR1")
-    params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
+    block = AndOrBlock(name=name)
+    block.params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
     mux = {f"INP{i + 1}": True for i in range(4)}
-    block = AndOrBlockConfig(name, params)()
-    out = block.on_tick(SimTime(0), mux)
+    out = block.update(SimTime(0), mux)
     assert out.outputs == {
         "OUT": enabled != inverted
     }  # At least one device exclusively enabled or inverted
@@ -42,18 +42,18 @@ def test_or_block_enabled_or_inverted(enabled: int, inverted: int):
 @pytest.mark.parametrize("high", varying_values_of_true)
 def test_all_enabled_and_block_for_inputs(high: int):
     name = ComponentID("AND1")
-    params = {f"{name}_ENA": 15, f"{name}_INV": 0}
+    block = AndOrBlock(name=name)
+    block.params = {f"{name}_ENA": all_true, f"{name}_INV": all_false}
     mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
-    block = AndOrBlockConfig(name, params)()
-    out = block.on_tick(SimTime(0), mux)
+    out = block.update(SimTime(0), mux)
     assert out.outputs == {"OUT": high == all_true}  # All inputs high
 
 
 @pytest.mark.parametrize("high", varying_values_of_true)
 def test_all_enabled_or_block_for_inputs(high: int):
     name = ComponentID("OR1")
-    params = {f"{name}_ENA": 15, f"{name}_INV": 0}
+    block = AndOrBlock(name=name)
+    block.params = {f"{name}_ENA": all_true, f"{name}_INV": all_false}
     mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
-    block = AndOrBlockConfig(name, params)()
-    out = block.on_tick(SimTime(0), mux)
+    out = block.update(SimTime(0), mux)
     assert out.outputs == {"OUT": high != all_false}  # At least one input high

--- a/tests/zebra/zebra.py
+++ b/tests/zebra/zebra.py
@@ -1,0 +1,33 @@
+import pytest
+from tickit.core.typedefs import ComponentID, SimTime
+
+from tickit_devices.zebra import ZebraDevice
+from tickit_devices.zebra.and_or_block import AndOrBlockConfig
+
+
+@pytest.fixture
+def zebra() -> ZebraDevice:
+    return ZebraDevice(ComponentID("zebra"))
+
+
+all_true = 15
+one_false = 14
+one_true = 1
+all_false = 0
+varying_values_of_true = {all_false, one_true, one_false, all_true}
+
+
+# # # # # AndOrBlock Tests # # # # #
+# TODO: Block system tests
+
+@pytest.mark.parametrize("enabled", varying_values_of_true)
+@pytest.mark.parametrize("inverted", varying_values_of_true)
+def test_all_true(enabled: int, inverted: int):
+    name = ComponentID("AND1")
+    params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
+    mux = {f"INP{i+1}": True for i in range(4)}
+    block = AndOrBlockConfig(name, params)()
+    out = block.on_tick(SimTime(0), mux)
+    assert out.outputs == {
+        enabled + inverted == all_true
+    }  # All devices either enabled or inverted

--- a/tests/zebra/zebra.py
+++ b/tests/zebra/zebra.py
@@ -1,14 +1,7 @@
 import pytest
 from tickit.core.typedefs import ComponentID, SimTime
 
-from tickit_devices.zebra import ZebraDevice
 from tickit_devices.zebra.and_or_block import AndOrBlockConfig
-
-
-@pytest.fixture
-def zebra() -> ZebraDevice:
-    return ZebraDevice(ComponentID("zebra"))
-
 
 all_true = 15
 one_false = 14
@@ -18,16 +11,52 @@ varying_values_of_true = {all_false, one_true, one_false, all_true}
 
 
 # # # # # AndOrBlock Tests # # # # #
-# TODO: Block system tests
 
 @pytest.mark.parametrize("enabled", varying_values_of_true)
 @pytest.mark.parametrize("inverted", varying_values_of_true)
-def test_all_true(enabled: int, inverted: int):
+def test_and_block_enabled_or_inverted(enabled: int, inverted: int):
     name = ComponentID("AND1")
     params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
-    mux = {f"INP{i+1}": True for i in range(4)}
+    mux = {f"INP{i + 1}": True for i in range(4)}
     block = AndOrBlockConfig(name, params)()
     out = block.on_tick(SimTime(0), mux)
     assert out.outputs == {
-        enabled + inverted == all_true
+        'OUT': enabled + inverted == all_true
     }  # All devices either enabled or inverted
+
+
+@pytest.mark.parametrize("enabled", varying_values_of_true)
+@pytest.mark.parametrize("inverted", varying_values_of_true)
+def test_or_block_enabled_or_inverted(enabled: int, inverted: int):
+    name = ComponentID("OR1")
+    params = {f"{name}_ENA": enabled, f"{name}_INV": inverted}
+    mux = {f"INP{i + 1}": True for i in range(4)}
+    block = AndOrBlockConfig(name, params)()
+    out = block.on_tick(SimTime(0), mux)
+    assert out.outputs == {
+        'OUT': enabled != inverted
+    }  # At least one device exclusively enabled or inverted
+
+
+@pytest.mark.parametrize("high", varying_values_of_true)
+def test_all_enabled_and_block_for_inputs(high: int):
+    name = ComponentID("AND1")
+    params = {f"{name}_ENA": 15, f"{name}_INV": 0}
+    mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
+    block = AndOrBlockConfig(name, params)()
+    out = block.on_tick(SimTime(0), mux)
+    assert out.outputs == {
+        'OUT': high == all_true
+    }  # All inputs high
+
+
+@pytest.mark.parametrize("high", varying_values_of_true)
+def test_all_enabled_or_block_for_inputs(high: int):
+    name = ComponentID("OR1")
+    params = {f"{name}_ENA": 15, f"{name}_INV": 0}
+    mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
+    block = AndOrBlockConfig(name, params)()
+    out = block.on_tick(SimTime(0), mux)
+    assert out.outputs == {
+        'OUT': high != all_false
+    }  # At least one input high

--- a/tests/zebra/zebra.py
+++ b/tests/zebra/zebra.py
@@ -12,6 +12,7 @@ varying_values_of_true = {all_false, one_true, one_false, all_true}
 
 # # # # # AndOrBlock Tests # # # # #
 
+
 @pytest.mark.parametrize("enabled", varying_values_of_true)
 @pytest.mark.parametrize("inverted", varying_values_of_true)
 def test_and_block_enabled_or_inverted(enabled: int, inverted: int):
@@ -21,7 +22,7 @@ def test_and_block_enabled_or_inverted(enabled: int, inverted: int):
     block = AndOrBlockConfig(name, params)()
     out = block.on_tick(SimTime(0), mux)
     assert out.outputs == {
-        'OUT': enabled + inverted == all_true
+        "OUT": enabled + inverted == all_true
     }  # All devices either enabled or inverted
 
 
@@ -34,7 +35,7 @@ def test_or_block_enabled_or_inverted(enabled: int, inverted: int):
     block = AndOrBlockConfig(name, params)()
     out = block.on_tick(SimTime(0), mux)
     assert out.outputs == {
-        'OUT': enabled != inverted
+        "OUT": enabled != inverted
     }  # At least one device exclusively enabled or inverted
 
 
@@ -45,9 +46,7 @@ def test_all_enabled_and_block_for_inputs(high: int):
     mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
     block = AndOrBlockConfig(name, params)()
     out = block.on_tick(SimTime(0), mux)
-    assert out.outputs == {
-        'OUT': high == all_true
-    }  # All inputs high
+    assert out.outputs == {"OUT": high == all_true}  # All inputs high
 
 
 @pytest.mark.parametrize("high", varying_values_of_true)
@@ -57,6 +56,4 @@ def test_all_enabled_or_block_for_inputs(high: int):
     mux = {f"INP{i + 1}": bool(high & (1 << i)) for i in range(4)}
     block = AndOrBlockConfig(name, params)()
     out = block.on_tick(SimTime(0), mux)
-    assert out.outputs == {
-        'OUT': high != all_false
-    }  # At least one input high
+    assert out.outputs == {"OUT": high != all_false}  # At least one input high


### PR DESCRIPTION
- Update Zebra implementation for newer adapter/system simulation behaviours
- Add tests for blocks and dummy config
- Zebra support with 4 each AND/OR blocks, each with 4 inputs
- Supports getting/setting params/muxes from adapter