### PR TITLE
Update for breaking name change to device component

### DIFF
--- a/src/tickit_devices/cryostream/__init__.py
+++ b/src/tickit_devices/cryostream/__init__.py
@@ -2,7 +2,7 @@ import pydantic.v1.dataclasses
 from tickit.adapters.io import TcpIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 
 from .cryostream import CryostreamAdapter, CryostreamDevice
 
@@ -25,7 +25,7 @@ class Cryostream(ComponentConfig):
                 ),
             )
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/eiger/__init__.py
+++ b/src/tickit_devices/eiger/__init__.py
@@ -2,7 +2,7 @@ import pydantic.v1.dataclasses
 from tickit.adapters.io import HttpIo, ZeroMqPushIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 
 from tickit_devices.eiger.eiger import EigerDevice
 from tickit_devices.eiger.eiger_adapters import EigerRESTAdapter, EigerZMQAdapter
@@ -35,7 +35,7 @@ class Eiger(ComponentConfig):
                 ),
             ),
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/femto/__init__.py
+++ b/src/tickit_devices/femto/__init__.py
@@ -2,7 +2,7 @@ import pydantic.v1.dataclasses
 from tickit.adapters.io import EpicsIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 
 from .current import CurrentDevice
 from .femto import FemtoAdapter, FemtoDevice
@@ -30,7 +30,7 @@ class Femto(ComponentConfig):
                 ),
             )
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/pneumatic/__init__.py
+++ b/src/tickit_devices/pneumatic/__init__.py
@@ -2,7 +2,7 @@ import pydantic.v1.dataclasses
 from tickit.adapters.io import EpicsIo
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 
 from .pneumatic import PneumaticAdapter, PneumaticDevice
 
@@ -29,7 +29,7 @@ class Pneumatic(ComponentConfig):
                 ),
             )
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/synchrotron/synchrotron_current.py
+++ b/src/tickit_devices/synchrotron/synchrotron_current.py
@@ -9,7 +9,7 @@ from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.tcp import CommandAdapter
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
@@ -186,7 +186,7 @@ class SynchrotronCurrent(ComponentConfig):
                 ),
             ),
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/synchrotron/synchrotron_machine.py
+++ b/src/tickit_devices/synchrotron/synchrotron_machine.py
@@ -9,7 +9,7 @@ from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.tcp import CommandAdapter
 from tickit.core.adapter import AdapterContainer
 from tickit.core.components.component import Component, ComponentConfig
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 from tickit.core.device import Device, DeviceUpdate
 from tickit.core.typedefs import SimTime
 from tickit.utils.byte_format import ByteFormat
@@ -209,7 +209,7 @@ class SynchrotronMachineStatus(ComponentConfig):
                 ),
             ),
         ]
-        return DeviceSimulation(
+        return DeviceComponent(
             name=self.name,
             device=device,
             adapters=adapters,

--- a/src/tickit_devices/zebra/zebra.py
+++ b/src/tickit_devices/zebra/zebra.py
@@ -3,7 +3,7 @@ from typing import Dict, Union
 
 from tickit.adapters.specifications import RegexCommand
 from tickit.adapters.system import BaseSystemSimulationAdapter
-from tickit.core.components.device_simulation import DeviceSimulation
+from tickit.core.components.device_component import DeviceComponent
 from tickit.core.management.event_router import InverseWiring, Wiring
 from tickit.core.typedefs import ComponentID
 
@@ -11,7 +11,7 @@ from tickit_devices.zebra._common import param_types, register_names
 
 
 class ZebraAdapter(BaseSystemSimulationAdapter):
-    _components: Dict[ComponentID, DeviceSimulation]
+    _components: Dict[ComponentID, DeviceComponent]
     params: dict[str, int]
     """
     Network adapter for a Zebra system simulation, which operates a TCP server for
@@ -34,7 +34,7 @@ class ZebraAdapter(BaseSystemSimulationAdapter):
 
     def setup_adapter(
         self,
-        components: Dict[ComponentID, DeviceSimulation],
+        components: Dict[ComponentID, DeviceComponent],
         wiring: Union[Wiring, InverseWiring],
     ) -> None:
         """


### PR DESCRIPTION
An unreleased version of tickit renames `DeviceSimulation` to `DeviceComponent`. This PR updates tickit-devices to fix this breaking change. Can be checked and merged on the next release of tickit.