### PR TITLE
Pin to latest required tickit change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 description = "Devices for tickit, an event-based device simulation framework"
 dependencies = [
-    "tickit>=0.4.2",
+    "tickit>=0.4.3",
     "typing_extensions",
     "softioc",
     "pydantic>1",


### PR DESCRIPTION
 #92, the name changing update was breaking and as such we need limit the required version of tickit.